### PR TITLE
typo

### DIFF
--- a/documentation/docs/wallet-app.mdx
+++ b/documentation/docs/wallet-app.mdx
@@ -46,7 +46,7 @@ Content-Type: application/json
 {
   "amount": 200,
   "assetCode" : "USD",
-  "assetScale": 2,
+  "assetScale": 3,
   "interval": "P1M",
   "scope": "$issuer.wallet/alice"
 }
@@ -62,7 +62,7 @@ Content-Type: application/json
   "name": "//issuer.wallet/mandates/2fad69d0-7997-4543-8346-69b418c479a6",
   "amount": 200,
   "assetCode" : "USD",
-  "assetScale": 2,
+  "assetScale": 3,
   "interval": "P1M",
   "startAt": "2020-01-22T00:00:00Z",
   "scope": "$issuer.wallet/alice",


### PR DESCRIPTION
AssetCode was 2, indicating $20/month not $2/month