### PR TITLE
Add PayID discovery

### DIFF
--- a/documentation/docs/discovery.mdx
+++ b/documentation/docs/discovery.mdx
@@ -111,7 +111,7 @@ payments** using Open Payments.
 
 Importantly, neither a PayID nor a Payment Pointer is sensitive in the same way
 that a payment card number is. They can be shared freely with no risk that funds
-will be pulled from the a discovered account without the account owner's consent
+will be pulled from the discovered account without the account owner's consent
 
 ## Account Metadata
 

--- a/documentation/docs/discovery.mdx
+++ b/documentation/docs/discovery.mdx
@@ -110,7 +110,7 @@ Users can share their PayID or Payment Pointers to both **get paid** and **make
 payments** using Open Payments.
 
 Importantly, neither a PayID nor a Payment Pointer is sensitive in the same way
-that a payment card number is. It can be shared freely with no risk that funds
+that a payment card number is. They can be shared freely with no risk that funds
 will be pulled from the a discovered account without the account owner's consent
 
 ## Account Metadata

--- a/documentation/docs/discovery.mdx
+++ b/documentation/docs/discovery.mdx
@@ -30,12 +30,11 @@ identifier called a **Payment Pointer**.
 
 ## Payment Pointers
 
-All entities in Open Payments are **resources** identified by, and addressable
-via, URLs in keeping with the
-[REST](https://tools.ietf.org/html/rfc7231#section-2) pattern. This includes
-[accounts](./accounts) which are the root resource in Open Payments. Discovery
-involves finding the URL of the account resource because all other resource URLs
-are relative to the account.
+In keeping with the [REST](https://tools.ietf.org/html/rfc7231#section-2)
+pattern, all entities in Open Payments are **resources** identified by, and
+addressable via, URLs. This includes [accounts](./accounts) which are the root
+resource in Open Payments. Discovery involves finding the URL of the account
+resource because all other resource URLs are relative to the account.
 
 > Example account URL:  
 > `https://wallet.example/accounts/dee69df8-be40-478f-9828-6267f4d42b01`
@@ -74,20 +73,47 @@ receiver).
 > Example Personal Payment Pointer:  
 > `$wallet.example/alice`
 
-Personal Payment Pointers are analogous to an email address or payment card
-number. Email addresses are given to counter-parties so that they can begin
-sending emails to the target inbox. Similarly, a payment card number can be
-given to a counter-party so that they can request payment from the target
+## PayID
+
+Another form of identifier that can be used by account owners is a PayID. A
+PayID identifies the account owner and not an individual account so it is
+possible for a client, given a PayID to discover multiple accounts they can
+transact with.
+
+These accounts may have different currencies and may have additional options
+making incoming payments.
+
+Discovery of accounts on an Open Payments server using a PayID is described in
+the [Open Payments PayID discovery protocol](./payid).
+
+### PayID vs Personal Payment Pointer
+
+While at first glance these may appear to be the same, they are intentionally
+different.
+
+A **Personal Payment Pointer** MUST point to an account that supports
+Interledger. A client that begins an Open Payments discovery algorithm with a
+Payment Pointer is guaranteed to discover an account that supports incoming
+payments via ILP.
+
+In contrast a PayID requires a more indirect discovery flow (via the account
+owner resource) it MAY be used to discover accounts connected to other payment
+networks or accounts denominated in different currencies.
+
+Both PayIDs and Personal Payment Pointers are analogous to an email address or
+payment card number. Email addresses are given to counter-parties so that they
+can begin sending emails to the target inbox. Similarly, a payment card number
+can be given to a counter-party so that they can request payment from the target
 account.
 
-Users can share their Personal Payment Pointers to both **get paid** and **make
+Users can share their PayID or Payment Pointers to both **get paid** and **make
 payments** using Open Payments.
 
-Importantly, a Payment Pointer is not sensitive in the same way that a payment
-card number is. It can be shared freely with no risk that funds will be pulled
-from the target account without the account owner's consent
+Importantly, neither a PayID nor a Payment Pointer is sensitive in the same way
+that a payment card number is. It can be shared freely with no risk that funds
+will be pulled from the a discovered account without the account owner's consent
 
-## Metadata
+## Account Metadata
 
 Account metadata is provided by an Open Payments Server as a JSON document that
 describes the various service endpoints that are available to:

--- a/documentation/docs/discovery.mdx
+++ b/documentation/docs/discovery.mdx
@@ -81,7 +81,7 @@ possible for a client, given a PayID to discover multiple accounts they can
 transact with.
 
 These accounts may have different currencies and may have additional options
-making incoming payments.
+for making incoming payments.
 
 Discovery of accounts on an Open Payments server using a PayID is described in
 the [Open Payments PayID discovery protocol](./payid).

--- a/documentation/docs/owners.mdx
+++ b/documentation/docs/owners.mdx
@@ -38,7 +38,7 @@ Create is not supported for owners.
 ### Get
 
 The following request is a non-normative example of a request for the meta-data
-for the account identified by the PayID: `alice$wallet.example`
+for the owner identified by the PayID: `alice$wallet.example`
 
 ```http
 GET /$/alice HTTP/1.1

--- a/documentation/docs/owners.mdx
+++ b/documentation/docs/owners.mdx
@@ -1,0 +1,114 @@
+---
+id: owners
+title: Owners
+---
+
+Owners represent the entity that owns an account. The owner resource can be used
+to discover the accounts owned by the entity, in order to setup a payment to or
+from the account.
+
+## Resource Representation
+
+The `application/json` representation of an owner resource provides the details
+of the owner as a JSON document.
+
+| Property | Type  | Description                      |
+| -------- | ----- | -------------------------------- |
+| id       | URL   | The URL identifying the owner    |
+| accounts | array | The accounts owned by the entity |
+
+The `accounts` property holds an array of account objects as described below:
+
+| Property   | Type   | Description                                                                       |
+| ---------- | ------ | --------------------------------------------------------------------------------- |
+| id         | URL    | The URL of the account resource                                                   |
+| assetCode  | string | The asset code of the amount (inherited from the underlying account)              |
+| assetScale | int32  | The scale of the amount (inherited from the underlying account)                   |
+| mediaTypes | array  | An array of media-types that can be requested when accessing the account resource |
+
+## APIs
+
+The owners API endpoint/resource URL is the URL discovered by the client through
+the [Open Payments PayID discovery](./payid) process.
+
+### Create
+
+Create is not supported for owners.
+
+### Get
+
+The following request is a non-normative example of a request for the meta-data
+for the account identified by the PayID: `alice$wallet.example`
+
+```http
+GET /$/alice HTTP/1.1
+Host: wallet.example
+Accept: application/json
+```
+
+The returned JSON document MUST contain the following claims:
+
+- `id` URL identifying the account owner.
+- `accounts` an array of account object as defined below.
+
+#### Accounts
+
+Each account object returned in the `accounts` array MUST contain the following
+claims:
+
+- `id` URL identifying the account. This is the account resource URL and can be
+  used as the basis for further Open Payments interaction on the account.
+- `assetCode` the currency of the account.
+- `assetScale` the natural scale of the account relative to the natural scale of
+  the asset. This is expressed as an integer which is the power of 10 that the
+  account balance must be divided by to get to the natural scale of the asset.
+  For example, if the asset is USD then a scale of 2 implies that the balance is
+  tracked in USD cents. (Must be divided by 100 to be show USD)
+- `mediaTypes` an array of strings that are valid media types for this account.
+
+#### Media Types
+
+By default, [account](./accounts) and [invoice](./invoices) resources are
+represented using the `application/json` media type.
+
+However, clients may request alternative representations which include
+additional payment details for payments into the account or against the invoice
+as described in the [payment details API](./payments).
+
+An example of such a media type is `application/ilp-stream+json` which will
+supplement the default representation with two additional properties the
+`ilpAddress` and `sharedSecret` which are used by the client to make payments to
+the account or against the invoice.
+
+The `mediaTypes` property of `account` objects returned in a response provide
+the set of media types that MAY be requested for the account.
+
+The list MUST include `application/json`.
+
+If the account is discoverable via a
+[Payment Pointer](./terminology#payment-pointer) the list MUST include
+`application/ilp-stream+json`.
+
+An error response uses the applicable HTTP status code value.
+
+The following is a non-normative example response:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{
+  "id": "https://wallet.example/$/alice",
+  "accounts" : [
+    {
+      "id": "",
+      "assetCode": "USD",
+      "assetScale" 2,
+      "mediaTypes": [
+        "application/json", 
+        "application/ilp-stream+json" 
+      ]
+    }
+  ]
+}
+```

--- a/documentation/docs/payid.mdx
+++ b/documentation/docs/payid.mdx
@@ -15,7 +15,7 @@ for Interledger-enabled accounts.
 Said differently, any account identified by a Payment Pointer can be paid into
 using the [STREAM](terminology#STREAM) protocol.
 
-This feature allows clients setup payments, for uses cases such
+This feature allows clients to setup payments, for uses cases such
 [web monetization](./web-monetization), with a single API call, to get the
 payment details, and be guaranteed that the receiving account supports ILP as
 payment method.

--- a/documentation/docs/payid.mdx
+++ b/documentation/docs/payid.mdx
@@ -1,0 +1,74 @@
+---
+id: payid
+title: PayID
+---
+
+import { Mermaid } from './Mermaid'
+
+By default, Open Payments interactions centre around an [account](./accounts)
+resource and all APIs are relative to the account URL.
+
+The account URL is [discovered](./discovery) through a
+[Payment Pointer](./terminology#payment-pointer) which is an account identifer
+for Interledger-enabled accounts.
+
+Said differently, any account identified by a Payment Pointer can be paid into
+using the [STREAM](terminology#STREAM) protocol.
+
+This feature allows clients setup payments, for uses cases such
+[web monetization](./web-monetization), with a single API call, to get the
+payment details, and be guaranteed that the receiving account supports ILP as
+payment method.
+
+A **PayID** is an alternative identifier which, unlike Payment Pointers that
+identify accounts, identifies [account owners](./terminology#account-owner).
+
+The
+[PayID URI specification](https://github.com/xpring-eng/rfcs/blob/master/payid/dist/spec/payid-uri.txt)
+defines the format of a PayID to be `acctpart "$" host`.
+
+With respect to Open Payments the `acctpart` is the account owner identifier and
+`host` is the origin of the Open Payments server.
+
+The following PayID identifies an account for the owner `alice` at the wallet
+`wallet.example`:
+
+> `alice$wallet.example`
+
+## Open Payments PayID Discovery
+
+As with all APIs in Open Payments the [owner](./owner.mdx) is a resource and is
+identified by a URL.
+
+The
+[PayID URI specification](https://github.com/xpring-eng/rfcs/blob/master/payid/dist/spec/payid-uri.txt)
+allows for any protocol to define a discovery protocol on top of the identifier.
+For Open Payments the discovery protocol is as follows:
+
+1. Given a PayID conforming to the prescribed format, `acctpart "$" host`,
+   extract the values **acctpart** and **host**.
+2. Let **path** be the string `/$/` concatenated with **acctpart**
+3. Let **account owner URL** be a new URL as defined in
+   [WHATWG URL](https://url.spec.whatwg.org/#concept-url) where:
+   1. The URL's scheme is `https`
+   2. The URL's host is **host**
+   3. The URL's path is **path**
+
+For example, the PayID `alice$wallet.example` resolves to the URL
+`https://wallet.example/$/alice`.
+
+The `/$/` path prefix minimizes the chance that Web servers will have path
+conflicts with their existing services.
+
+## Privacy
+
+Open Payments servers that support PayIDs SHOULD put mitigations in place to
+prevent clients "farming" data about the account owners that have accounts on
+the server.
+
+## API
+
+Having resolved the owner API endpoint URL a client can use the owner API to
+discover the accounts available to it and setup a new transaction.
+
+See the [owners API](./owners) for more details.

--- a/documentation/docs/payments.mdx
+++ b/documentation/docs/payments.mdx
@@ -66,3 +66,43 @@ Content-Type: application/spsp4+json
   "shared_secret": "6jR5iNIVRvqeasJeCty6C+YB5X9FhSOUPCL/5nha5Vs="
 }
 ```
+
+## XRP Ledger
+
+The `application/xrpl+json` representation of an invoice or account resource
+includes the following **additional** properties for paying the receiver via the
+XRP Ledger:
+
+| Property       | Type               | Description                                                                              |
+| -------------- | ------------------ | ---------------------------------------------------------------------------------------- |
+| xrplAddress    | XRP Ledger Address | The XRP Ledger address to use when making payments to the account or against the invoice |
+| destinationTag | string             | The destination tag to use when making payments to the account or against the invoice    |
+
+The following is a non-normative example where the client gets the details to
+pay an account via the XRP Ledger:
+
+```http
+GET alice HTTP/1.1
+Host: wallet.example
+Accept: application/xrpl+json
+```
+
+with a non-normative response from the Open Payments Server of:
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/spsp4+json
+
+{
+  "id": "https://wallet.example/alice",
+  "accountServicer": "https://wallet.example",
+  "assetCode": "USD",
+  "assetScale" 2,
+  "auth" : {
+    "authorization_endpoint": "https://auth.wallet.example/authorize",
+    "token_endpoint": "https://auth.wallet.example/token",
+  }
+  "xrplAddress": "XTVQWr6BhgBLW2jbFyqqufgq8T9eN7KresB684ZSHKQ3oDth",
+  "destinationTag": "543237"
+}
+```

--- a/documentation/sidebars.js
+++ b/documentation/sidebars.js
@@ -3,6 +3,7 @@ module.exports = {
     Overview: [
       'introduction',
       'discovery',
+      'payid',
       'flow',
       'delegated',
       'auth',
@@ -18,6 +19,7 @@ module.exports = {
       'payments',
       'mandates',
       'charges',
+      'owners'
     ],
     'Use Cases': [
       'p2p', 


### PR DESCRIPTION
A first attempt at adding support for PayID to Open Payments.

PayID is intentionally specified as a loose set of specifications (URI spec, Discovery spec and Protocol spec) to allow some mix and match. I have embraced that here to try and define a protocol that is as simple as Open Payments but achieves the same goals as the PayID protocol:

1. I have not used PayID Discovery but have gone for something simple that is almost the same as PayID Discovery manual mode but with a special path prefix `/$/` to avoid collisions and make it easy for Open Payments servers to write URL re-write rules for all requests of this type.
2. I have built on the existing Open Payments feature of doing a `GET` on account or invoice URLs with a different media type to get payment details. I added an XRP example which could be compared to the example in the PayID Protocol RFC to get an idea of the differences.
3. I considered the return types in PayID Protocol to be too complex. I didn't see the value of having different AddressDetails types. Instead, each payment details type can define the appropriate additional properties it will add to an account or invoice resource and a client (knowing the media type) will know how to parse those out and use them.
4. I couldn't see what value the payment network and environment properties added since these are implicit in the media type so have left them out.

I've preserved the guarantee that an account discovered from a Payment Pointer MUST support ILP but by using a PayID a client has more flexibility (but also a bit more work to do to discover the account it needs).

I'd like to still add something compatible with the Proof Of Control Signature but need to understand a little more about what problem this is solving.

To review locally:
```sh
git clone https://github.com/interledger/open-payments.git
cd open-payments
git checkout ahb/payid
cd documentation
yarn
yarn start
```