### PR TITLE
chore: replace openapi validator

### DIFF
--- a/.github/workflows/openapi.yaml
+++ b/.github/workflows/openapi.yaml
@@ -17,8 +17,8 @@ jobs:
 
       - name: Validate open-api-spec.yaml
         run: |
-          npx @redocly/openapi-cli lint open-api-spec.yaml
+          npx @stoplight/spectral-cli lint open-api-spec.yaml
 
       - name: Validate auth-server-open-api-spec.yaml
         run: |
-          npx @redocly/openapi-cli lint auth-server-open-api-spec.yaml
+          npx @stoplight/spectral-cli lint auth-server-open-api-spec.yaml

--- a/.spectral.json
+++ b/.spectral.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["spectral:oas", "spectral:asyncapi"]
+}

--- a/open-api-spec.yaml
+++ b/open-api-spec.yaml
@@ -267,6 +267,8 @@ paths:
                       assetCode: USD
                       assetScale: 2
                     description: Thank you for the shoes.
+                    createdAt: '2022-03-12T23:20:50.52Z'
+                    updatedAt: '2022-04-01T10:24:36.11Z'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -988,12 +990,12 @@ components:
         createdAt:
           type: string
           format: date-time
-          pattern: '2022-03-12T23:20:50.52Z'
+          example: '2022-03-12T23:20:50.52Z'
           description: The date and time when the outgoing payment was created.
         updatedAt:
           type: string
           format: date-time
-          pattern: '2022-04-01T10:24:36.11Z'
+          example: '2022-04-01T10:24:36.11Z'
           description: The date and time when the outgoing payment was updated.
       required:
         - id
@@ -1065,7 +1067,7 @@ components:
         createdAt:
           type: string
           format: date-time
-          pattern: '2022-03-12T23:20:50.52Z'
+          example: '2022-03-12T23:20:50.52Z'
           description: The date and time when the quote was created.
     amount:
       title: Amount


### PR DESCRIPTION
[`spectral`](https://github.com/stoplightio/spectral) appears to be more popular and caught errors/warnings missed by [`redocly/openapi-cli`](https://github.com/Redocly/openapi-cli).

Validation can be performed locally by running:
```
docker run --rm -it -v $(pwd):/tmp stoplight/spectral lint --ruleset "/tmp/.spectral.json" "/tmp/open-api-spec.yaml"
```