### PR TITLE
chore: specify required fields

### DIFF
--- a/open-api-spec.yaml
+++ b/open-api-spec.yaml
@@ -842,6 +842,11 @@ components:
           format: uri
           description: The URL of the authorization server endpoint for getting grants and access tokens for this account.
           readOnly: true
+      required:
+        - id
+        - assetCode
+        - assetScale
+        - authServer
       additionalProperties: false
       examples:
         - id: 'https://openpayments.guide/alice'

--- a/open-api-spec.yaml
+++ b/open-api-spec.yaml
@@ -97,6 +97,8 @@ paths:
                     externalRef: INV2022-02-0137
                     ilpApddress: g.ilp.iwuyge987y.98y08y
                     sharedSecret: 6jR5iNIVRvqeasJeCty6C+YB5X9FhSOUPCL/5nha5Vs=
+                    createdAt: '2022-03-12T23:20:50.52Z'
+                    updatedAt: '2022-04-01T10:24:36.11Z'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -915,6 +917,13 @@ components:
           type: string
           format: date-time
           description: The date and time when the incoming payment was updated.
+      required:
+        - id
+        - accountId
+        - state
+        - receivedAmount
+        - createdAt
+        - updatedAt
     outgoing-payment:
       title: Outgoing Payment
       description: 'An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the account.'

--- a/open-api-spec.yaml
+++ b/open-api-spec.yaml
@@ -95,7 +95,7 @@ paths:
                       assetScale: 2
                     expiresAt: '2022-02-03T23:20:50.52Z'
                     externalRef: INV2022-02-0137
-                    ilpApddress: g.ilp.iwuyge987y.98y08y
+                    ilpAddress: g.ilp.iwuyge987y.98y08y
                     sharedSecret: 6jR5iNIVRvqeasJeCty6C+YB5X9FhSOUPCL/5nha5Vs=
                     createdAt: '2022-03-12T23:20:50.52Z'
                     updatedAt: '2022-04-01T10:24:36.11Z'
@@ -122,6 +122,7 @@ paths:
                 externalRef:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+              additionalProperties: false
             examples:
               Create incoming payment for $25 to pay invoice INV2022-02-0137:
                 value:
@@ -310,6 +311,7 @@ paths:
                 externalRef:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+              additionalProperties: false
         description: |-
           A subset of the outgoing payments schema is accepted as input to create a new outgoing payment.
 
@@ -466,7 +468,7 @@ paths:
                   value:
                     id: 'https://openpayments.guide/alice/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
                     accountId: 'https://openpayments.guide/alice/'
-                    receivingAccount: 'https://openpayments.guide/bob/'
+                    receivingPayment: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                     sendAmount:
                       value: '2500'
                       assetCode: USD
@@ -514,6 +516,7 @@ paths:
                   $ref: '#/components/schemas/amount'
                 sendAmount:
                   $ref: '#/components/schemas/amount'
+              additionalProperties: false
         description: |-
           A subset of the quotes schema is accepted as input to create a new quote.
 
@@ -705,6 +708,7 @@ paths:
                     - completed
               required:
                 - state
+              additionalProperties: false
             examples:
               Complete Incoming Payment:
                 value:
@@ -838,6 +842,7 @@ components:
           format: uri
           description: The URL of the authorization server endpoint for getting grants and access tokens for this account.
           readOnly: true
+      additionalProperties: false
       examples:
         - id: 'https://openpayments.guide/alice'
           publicName: Alice
@@ -901,7 +906,7 @@ components:
         externalRef:
           type: string
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
-        ilpApddress:
+        ilpAddress:
           type: string
           description: The ILP address to use when establishing a STREAM connection.
           readOnly: true
@@ -924,6 +929,7 @@ components:
         - receivedAmount
         - createdAt
         - updatedAt
+      additionalProperties: false
     outgoing-payment:
       title: Outgoing Payment
       description: 'An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the account.'
@@ -1018,6 +1024,7 @@ components:
         - sentAmount
         - createdAt
         - updatedAt
+      additionalProperties: false
     quote:
       title: Quote
       description: A **quote** resource represents the quoted amount details with which an Outgoing Payment may be created.
@@ -1076,6 +1083,14 @@ components:
           type: string
           format: date-time
           description: The date and time when the quote was created.
+      required:
+        - id
+        - accountId
+        - receivingPayment
+        - sendAmount
+        - receiveAmount
+        - createdAt
+      additionalProperties: false
     amount:
       title: Amount
       type: object
@@ -1114,6 +1129,7 @@ components:
         - value
         - assetCode
         - assetScale
+      additionalProperties: false
     pagination:
       description: ''
       type: object
@@ -1145,6 +1161,7 @@ components:
         last:
           type: number
           description: Number of entries requested using backward pagination.
+      additionalProperties: false
     list-incoming-payments:
       title: list-incoming-payments
       type: object
@@ -1155,6 +1172,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/incoming-payment'
+      additionalProperties: false
       examples:
         - pagination:
             startCursor: 241de237-f989-42be-926d-c0c1fca57708
@@ -1178,8 +1196,6 @@ components:
               updatedAt: '2022-04-01T10:24:36.11Z'
               description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
               externalRef: Coffee w/ Mo on 10 March 22
-              ilpApddress: g.ilp.iwuyge987y.98y08y
-              sharedSecret: 6jR5iNIVRvqeasJeCty6C+YB5X9FhSOUPCL/5nha5Vs=
         - pagination:
             startCursor: 241de237-f989-42be-926d-c0c1fca57708
             endCursor: 315581f8-9967-45a0-9cd3-87b60b6d6414
@@ -1202,8 +1218,6 @@ components:
               updatedAt: '2022-04-01T10:24:36.11Z'
               description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
               externalRef: Coffee w/ Mo on 10 March 22
-              ilpApddress: g.ilp.iwuyge987y.98y08y
-              sharedSecret: 6jR5iNIVRvqeasJeCty6C+YB5X9FhSOUPCL/5nha5Vs=
     list-outgoing-payments:
       title: list-outgoing-payments
       type: object
@@ -1214,6 +1228,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/outgoing-payment'
+      additionalProperties: false
       examples:
         - pagination:
             startCursor: 241de237-f989-42be-926d-c0c1fca57708
@@ -1269,6 +1284,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/quote'
+      additionalProperties: false
       examples:
         - pagination:
             startCursor: 241de237-f989-42be-926d-c0c1fca57708


### PR DESCRIPTION
Disallow additional properties.
Fix `ilpAddress` typo.

Note that `ilpApddress` and `sharedSecret` are optional since the same schema is used for getting and listing incoming payments.
Ideally those fields are required for the former (or potentially moved to their own endpoint).