### PR TITLE
chore: define account id as path parameter

### DIFF
--- a/open-api-spec.yaml
+++ b/open-api-spec.yaml
@@ -22,10 +22,7 @@ info:
   contact:
     email: tech@interledger.org
 servers:
-  - url: 'https://openpayments.guide/alice'
-    description: alice
-  - url: 'https://openpayments.guide/bob'
-    description: bob
+  - url: 'https://openpayments.guide'
 tags:
   - name: account
     description: account operations
@@ -36,7 +33,7 @@ tags:
   - name: quote
     description: quote operations
 paths:
-  /:
+  '/{id}':
     get:
       summary: Get a Payment Pointer
       tags:
@@ -66,7 +63,14 @@ paths:
 
         The content should be slow changing and cacheable for long periods. Servers SHOULD use cache control headers.
       security: []
-  /incoming-payments:
+    parameters:
+      - schema:
+          type: string
+        name: id
+        in: path
+        required: true
+        description: Account identifier
+  '/{accountId}/incoming-payments':
     post:
       summary: Create an Incoming Payment
       tags:
@@ -247,7 +251,14 @@ paths:
           description: The cursor key to list from
       tags:
         - incoming-payment
-  /outgoing-payments:
+    parameters:
+      - schema:
+          type: string
+        name: accountId
+        in: path
+        required: true
+        description: Account identifier
+  '/{accountId}/outgoing-payments':
     post:
       summary: Create an Outgoing Payment
       tags:
@@ -446,7 +457,14 @@ paths:
           description: The cursor key to list from
       tags:
         - outgoing-payment
-  /quotes:
+    parameters:
+      - schema:
+          type: string
+        name: accountId
+        in: path
+        required: true
+        description: Account identifier
+  '/{accountId}/quotes':
     post:
       summary: Create a Quote
       tags:
@@ -622,7 +640,14 @@ paths:
           description: The cursor key to list from
       tags:
         - quote
-  '/incoming-payments/{id}':
+    parameters:
+      - schema:
+          type: string
+        name: accountId
+        in: path
+        required: true
+        description: Account identifier
+  '/{accountId}/incoming-payments/{id}':
     get:
       summary: Get an Incoming Payment
       tags:
@@ -664,6 +689,12 @@ paths:
           description: Incoming Payment Not Found
       description: A client can fetch the latest state of an incoming payment to determine the amount received into the account.
     parameters:
+      - schema:
+          type: string
+        name: accountId
+        in: path
+        required: true
+        description: Account identifier
       - schema:
           type: string
           format: uuid
@@ -710,7 +741,7 @@ paths:
         description: Update the state of the incoming payment to `completed`.
       tags:
         - incoming-payment
-  '/outgoing-payments/{id}':
+  '/{accountId}/outgoing-payments/{id}':
     get:
       summary: Get an Outgoing Payment
       tags:
@@ -756,12 +787,18 @@ paths:
     parameters:
       - schema:
           type: string
+        name: accountId
+        in: path
+        required: true
+        description: Account identifier
+      - schema:
+          type: string
           format: uuid
         name: id
         in: path
         required: true
         description: Outgoing Payment identifier
-  '/quotes/{id}':
+  '/{accountId}/quotes/{id}':
     get:
       summary: Get a Quote
       tags:
@@ -798,6 +835,12 @@ paths:
           description: Quote Not Found
       description: A client can fetch the latest state of a quote.
     parameters:
+      - schema:
+          type: string
+        name: accountId
+        in: path
+        required: true
+        description: Account identifier
       - schema:
           type: string
           format: uuid


### PR DESCRIPTION
This is needed for request validation both now and when the account id is removed from the `/{accountId}/incoming-payments/{id}` path (in order for the spec to distinguish between paths that do and do not include the account id).