### PR TITLE
fix: updated required fields for /introspect

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -388,9 +388,6 @@ paths:
                     $ref: '#/components/schemas/key'
                 required:
                   - active
-                  - grant
-                  - access
-                  - key
               examples:
                 Token Introspection:
                   value:


### PR DESCRIPTION
Updates the required response fields for `/introspect` on the auth server so that only `active` is required. This should match the implementation it has on [Rafiki](https://github.com/interledger/rafiki/blob/551eb5323876d2f111a7f36ebb0ae333710e8edb/packages/auth/src/accessToken/service.ts#L52-L73).