### PR TITLE
fix: change required fields for /continue

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -141,8 +141,6 @@ paths:
                     $ref: '#/components/schemas/access_token'
                   continue:
                     $ref: '#/components/schemas/continue'
-                required:
-                  - continue
               examples:
                 Continuing After a Completed Interaction:
                   value:


### PR DESCRIPTION
Remove `required` status from the `continue` field in the response from the `/continue` path.

[From the GNAP spec](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-5.1) (emphasis mine):
> The grant response ([Section 3](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-3)) MAY contain any newly-created access
   tokens ([Section 3.2](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-3.2)) or newly-released subject claims ([Section 3.4](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-3.4)).
   **The response MAY contain a new "continue" response ([Section 3.1](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-3.1)) as
   described above.**  The response SHOULD NOT contain any interaction
   responses ([Section 3.3](https://datatracker.ietf.org/doc/html/draft-ietf-gnap-core-protocol#section-3.3)).

The current requirement is causing OpenAPI validation on https://github.com/interledger/rafiki/pull/372 to fail.