### PR TITLE
feat: add quote to access schema

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -849,7 +849,6 @@ components:
             enum:
               - read
               - create
-              - list
         identifier:
           type: string
           description: A string identifier indicating a specific resource at the RS.

--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -514,7 +514,7 @@ components:
         - $ref: '#/components/schemas/access-account'
         - $ref: '#/components/schemas/access-incoming'
         - $ref: '#/components/schemas/access-outgoing'
-        - $ref: '#components/schemas/access-quote'
+        - $ref: '#/components/schemas/access-quote'
       description: The access associated with the access token is described using objects that each contain multiple dimensions of access.
     limits-outgoing:
       title: limits-outgoing

--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -815,33 +815,6 @@ components:
       required:
         - type
         - actions
-    access-quote:
-      title: access-quote
-      type: object
-      properties:
-        type:
-          type: string
-          enum:
-            - quote
-            description: The type of resource request as a string.  This field defines which other fields are allowed in the request object.
-        actions:
-          type: array
-          description: The types of actions the client will take at the RS as an array of strings.
-          items:
-            type: string
-            enum:
-              - read
-              - create
-        identifier:
-          type: string
-          format: uri
-          description: A string identifier indicating a specific resource at the RS.
-        interval:
-          type: string
-          description: '[ISO8601 repeating interval](https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals)'
-        required:
-          - type
-          - actions
     limits-incoming:
       title: limits-incoming
       type: object
@@ -859,6 +832,33 @@ components:
           type: string
           description: Incoming payments MUST be created using this external reference.
       description: 'Open Payments specific property that defines the limits under which incoming payments can be created. '
+    access-quote:
+      title: access-quote
+      type: object
+      properties:
+        type:
+          type: string
+          description: The type of resource request as a string.  This field defines which other fields are allowed in the request object.
+          enum:
+            - quote
+        actions:
+          type: array
+          description: The types of actions the client will take at the RS as an array of strings.
+          items:
+            type: string
+            enum:
+              - read
+              - create
+        identifier:
+          type: string
+          description: A string identifier indicating a specific resource at the RS.
+          format: uri
+        interval:
+          type: string
+          description: '[ISO8601 repeating interval](https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals)'
+      required:
+        - type
+        - actions
   securitySchemes:
     GNAP:
       name: Authorization

--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -509,10 +509,12 @@ components:
           account: '#/components/schemas/access-account'
           incoming-payment: '#/components/schemas/access-incoming'
           outgoing-payment: '#/components/schemas/access-outgoing'
+          quote: '#/components/schemas/access-quote'
       oneOf:
         - $ref: '#/components/schemas/access-account'
         - $ref: '#/components/schemas/access-incoming'
         - $ref: '#/components/schemas/access-outgoing'
+        - $ref: '#components/schemas/access-quote'
       description: The access associated with the access token is described using objects that each contain multiple dimensions of access.
     limits-outgoing:
       title: limits-outgoing
@@ -813,6 +815,33 @@ components:
       required:
         - type
         - actions
+    access-quote:
+      title: access-quote
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - quote
+            description: The type of resource request as a string.  This field defines which other fields are allowed in the request object.
+        actions:
+          type: array
+          description: The types of actions the client will take at the RS as an array of strings.
+          items:
+            type: string
+            enum:
+              - read
+              - create
+        identifier:
+          type: string
+          format: uri
+          description: A string identifier indicating a specific resource at the RS.
+        interval:
+          type: string
+          description: '[ISO8601 repeating interval](https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals)'
+        required:
+          - type
+          - actions
     limits-incoming:
       title: limits-incoming
       type: object

--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -849,13 +849,11 @@ components:
             enum:
               - read
               - create
+              - list
         identifier:
           type: string
           description: A string identifier indicating a specific resource at the RS.
           format: uri
-        interval:
-          type: string
-          description: '[ISO8601 repeating interval](https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals)'
       required:
         - type
         - actions


### PR DESCRIPTION
The lack of the `quote` access type in the OpenAPI schema is blocking token introspection for Quote grants.