### PR TITLE
feat: add exp, nbf, revoked, key_ops to key schema

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -732,6 +732,15 @@ components:
             x:
               type: string
               description: Public key encoded using the `base64url` encoding.
+            nbf:
+              type: integer
+              description: UNIX timestamp indicating the earliest this key may be used.
+            exp:
+              type: integer
+              description: UNIX timestamp indicating the latest this key may be used.
+            revoked:
+              type: boolean
+              description: The revocation status of the key.
           additionalProperties: false
       required:
         - proof

--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -732,6 +732,14 @@ components:
             x:
               type: string
               description: Public key encoded using the `base64url` encoding.
+            key_ops:
+              type: array
+              description: Array of allowed operations this key may be used for.
+              items:
+                type: string
+                enum:
+                  - sign
+                  - verify
             nbf:
               type: integer
               description: UNIX timestamp indicating the earliest this key may be used.


### PR DESCRIPTION
The `key` field in the `/introspect` response is currently returning `nbf`, `exp`, `revoked` and `key_ops`, which isn't reflected in the OpenAPI spec yet.