### PR TITLE
fix(auth): remove separate identifier property

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -531,16 +531,10 @@ paths:
               schema:
                 type: object
                 properties:
-                  identifier:
-                    type: string
-                    format: uri
-                    description: A string identifier indicating a specific resource at the RS.
                   access:
                     type: array
                     items:
                       $ref: '#/components/schemas/access'
-                required:
-                  - identifier
         '404':
           description: Not Found
       operationId: get-grant


### PR DESCRIPTION
- Removes the `identifier` property from `/grant/{id}/{nonce}` because `identifier` is a property of each `access` element rather than a top-level member