### PR TITLE
fix spec syntax

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -577,7 +577,9 @@ components:
           description: '[ISO8601 repeating interval](https://en.wikipedia.org/wiki/ISO_8601#Repeating_intervals)'
       required:
         - interval
-        - oneOf - sendAmount - receiveAmount
+        - oneOf
+        - sendAmount
+        - receiveAmount
     limits-outgoing:
       title: limits-outgoing
       description: Open Payments specific property that defines the limits under which outgoing payments can be created.


### PR DESCRIPTION
I came across a syntax error from this line while using [openapi-typescript](https://github.com/drwpow/openapi-typescript)