### PR TITLE
chore: restrict access actions

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -821,6 +821,16 @@ components:
               - read-all
               - list
               - list-all
+          allOf:
+            - contains:
+                $ref: '#/components/schemas/read-actions'
+              minContains: 0
+              maxContains: 1
+            - contains:
+                $ref: '#/components/schemas/list-actions'
+              minContains: 0
+              maxContains: 1
+          uniqueItems: true
         identifier:
           type: string
           format: uri
@@ -854,6 +864,16 @@ components:
               - read-all
               - list
               - list-all
+          allOf:
+            - contains:
+                $ref: '#/components/schemas/read-actions'
+              minContains: 0
+              maxContains: 1
+            - contains:
+                $ref: '#/components/schemas/list-actions'
+              minContains: 0
+              maxContains: 1
+          uniqueItems: true
         identifier:
           type: string
           format: uri
@@ -878,9 +898,24 @@ components:
             enum:
               - create
               - read
+              - read-all
+          allOf:
+            - contains:
+                $ref: '#/components/schemas/read-actions'
+              minContains: 0
+              maxContains: 1
+          uniqueItems: true
       required:
         - type
         - actions
+    read-actions:
+      enum:
+        - read
+        - read-all
+    list-actions:
+      enum:
+        - list
+        - list-all
   securitySchemes:
     GNAP:
       name: Authorization


### PR DESCRIPTION
Disallow `read` with `read-all`.
Disallow `list` with `list-all`.
Disallow duplicate actions.

- fixes #178 