### PR TITLE
feat: set response body for redirects to string

### DIFF
--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -418,6 +418,10 @@ paths:
         - grant
       responses:
         '302':
+          content:
+            text/html:
+              schema:
+                type: string
           description: Found
           headers:
             Location:

--- a/auth-server-open-api-spec.yaml
+++ b/auth-server-open-api-spec.yaml
@@ -422,6 +422,7 @@ paths:
             text/html:
               schema:
                 type: string
+                nullable: true
           description: Found
           headers:
             Location:


### PR DESCRIPTION
Some server frameworks (i.e. Koa) also include a string body in the response of its native redirect function. This will make such responses passable in the OpenAPI spec.