### PR TITLE
fix: specify working directory for rdme publish

### DIFF
--- a/.github/workflows/publish-openapi.yaml
+++ b/.github/workflows/publish-openapi.yaml
@@ -19,12 +19,12 @@ jobs:
       - uses: actions/checkout@v3
         name: Check out repository
 
-      - uses: readmeio/rdme@7.2.0
+      - uses: readmeio/rdme@7.5.0
         name: Sync Open Payments API spec
         with:
-          rdme: openapi openapi/RS/openapi.yaml --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_OP_API_ID }}
+          rdme: openapi openapi.yaml --workingDirectory=openapi/RS --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_OP_API_ID }}
 
-      - uses: readmeio/rdme@7.2.0
+      - uses: readmeio/rdme@7.5.0
         name: Sync Auth Server API spec
         with:
-          rdme: openapi openapi/AS/client/openapi.yaml --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_AUTH_API_ID }}
+          rdme: openapi openapi.yaml --workingDirectory=openapi/AS/client --key=${{ secrets.README_API_KEY }} --id=${{ secrets.README_AUTH_API_ID }}


### PR DESCRIPTION
The `rdme` cli appears to resolve relative paths (to the shared schemas file) based on the working directory instead of the file path itself.
Use `rdme`'s  [`--workingDirectory`](https://github.com/readmeio/rdme#override-the-working-directory)

- fixes #199 

This was tested here:
https://github.com/interledger/open-payments/commits/bw-test-fix