### PR TITLE
feat: specify redirect body for finishing interactions

### DIFF
--- a/openapi/AS/IdP/openapi.yaml
+++ b/openapi/AS/IdP/openapi.yaml
@@ -60,6 +60,11 @@ paths:
       operationId: get-finish-interaction
       responses:
         '302':
+          content:
+            text/html:
+              schema:
+                type: string
+                nullable: true
           description: Found
           headers:
             Location:


### PR DESCRIPTION
Specifies the possible values of the redirect response body for interaction completion like was previously done for the interaction start response.