### PR TITLE
feat: use nullable limits and openapi-compliant uniqueness for access schema

### DIFF
--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -16,25 +16,8 @@ components:
       description: A description of the rights associated with this access token.
       items:
         $ref: '#/components/schemas/access-item'
-      allOf:
-        - contains:
-            properties:
-              type:
-                const: incoming-payment
-          minContains: 0
-          maxContains: 1
-        - contains:
-            properties:
-              type:
-                const: outgoing-payment
-          minContains: 0
-          maxContains: 1
-        - contains:
-            properties:
-              type:
-                const: quote
-          minContains: 0
-          maxContains: 1
+      uniqueItems: true
+      maxItems: 3
     access-item:
       discriminator:
         propertyName: type
@@ -259,6 +242,7 @@ components:
       title: limits-outgoing
       description: Open Payments specific property that defines the limits under which outgoing payments can be created.
       type: object
+      nullable: true
       properties:
         receiver:
           $ref: '#/components/schemas/receiver'

--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -241,8 +241,9 @@ components:
     limits-outgoing:
       title: limits-outgoing
       description: Open Payments specific property that defines the limits under which outgoing payments can be created.
-      type: object
-      nullable: true
+      type:
+        - object
+        - null
       properties:
         receiver:
           $ref: '#/components/schemas/receiver'

--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -241,9 +241,7 @@ components:
     limits-outgoing:
       title: limits-outgoing
       description: Open Payments specific property that defines the limits under which outgoing payments can be created.
-      type:
-        - object
-        - null
+      type: [object, "null"]
       properties:
         receiver:
           $ref: '#/components/schemas/receiver'


### PR DESCRIPTION
Addresses (but doesn't really fix) https://github.com/interledger/rafiki/issues/630. This spec is less strict to allow valid responses from the AS to pass validation, but is a bit too loose for what we actually want to achieve with it. The main restriction that this doesn't cover is:
* The spec does not restrict a grant to (at most) one of each `type` of access.