### PR TITLE
feat: remove allof

### DIFF
--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -52,15 +52,6 @@ components:
               - read-all
               - list
               - list-all
-          allOf:
-            - contains:
-                $ref: '#/components/schemas/read-actions'
-              minContains: 0
-              maxContains: 1
-            - contains:
-                $ref: '#/components/schemas/list-actions'
-              minContains: 0
-              maxContains: 1
           uniqueItems: true
         identifier:
           type: string
@@ -89,15 +80,6 @@ components:
               - read-all
               - list
               - list-all
-          allOf:
-            - contains:
-                $ref: '#/components/schemas/read-actions'
-              minContains: 0
-              maxContains: 1
-            - contains:
-                $ref: '#/components/schemas/list-actions'
-              minContains: 0
-              maxContains: 1
           uniqueItems: true
         identifier:
           type: string
@@ -127,11 +109,6 @@ components:
               - create
               - read
               - read-all
-          allOf:
-            - contains:
-                $ref: '#/components/schemas/read-actions'
-              minContains: 0
-              maxContains: 1
           uniqueItems: true
       required:
         - type


### PR DESCRIPTION
Remove `allof` since it is unsupported by OpenAPI. Right now it's essentially functioning like a `oneOf`, where certain items are _required_ to be in a list of `actions`.  Is a band-aid fix for https://github.com/interledger/rafiki/issues/630 - it doesn't address the core issue.