### PR TITLE
fix: move workflow_run in publish action

### DIFF
--- a/.github/workflows/publish-openapi.yaml
+++ b/.github/workflows/publish-openapi.yaml
@@ -1,19 +1,14 @@
 name: OpenAPI Publisher
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - openapi/**
+  workflow_run:
+    workflows: ['OpenAPI Validator']
+    branches: [main]
+    types:
+      - completed
 
 jobs:
   publish:
-    workflow_run:
-      workflows: ['OpenAPI Validator']
-      branches: [main]
-      types:
-        - completed
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run