### PR TITLE
chore: move json-web-key to shared schemas

### DIFF
--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -838,7 +838,7 @@ components:
         keys:
           type: array
           items:
-            $ref: '#/components/schemas/json-web-key'
+            $ref: ./schemas.yaml#/components/schemas/json-web-key
           readOnly: true
       required:
         - keys
@@ -1256,51 +1256,6 @@ components:
         - hasNextPage
         - hasPreviousPage
       additionalProperties: false
-    json-web-key:
-      type: object
-      properties:
-        kid:
-          type: string
-        alg:
-          type: string
-          description: 'The cryptographic algorithm family used with the key. The only allowed value is `EdDSA`. '
-          enum:
-            - EdDSA
-        use:
-          type: string
-          enum:
-            - sig
-        kty:
-          type: string
-          enum:
-            - OKP
-        crv:
-          type: string
-          enum:
-            - Ed25519
-        x:
-          type: string
-          pattern: '^[a-zA-Z0-9-_]+$'
-          description: The base64 url-encoded public key.
-      required:
-        - kid
-        - alg
-        - kty
-        - crv
-        - x
-      title: Ed25519 Public Key
-      description: A JWK representation of an Ed25519 Public Key
-      examples:
-        - kid: key-1
-          use: sig
-          kty: OKP
-          crv: Ed25519
-          x: 11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo
-        - kid: '2022-09-02'
-          use: sig
-          kty: OKP
-          crv: Ed25519
-          x: oy0L_vTygNE4IogRyn_F5GmHXdqYVjIXkWs2jky7zsI
   securitySchemes:
     GNAP:
       name: Authorization

--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -186,3 +186,48 @@ components:
       examples:
         - 'https://openpayments.guide/alice/incoming-payments/08394f02-7b7b-45e2-b645-51d04e7c330c'
         - 'https://openpayments.guide/connections/016da9d5-c9a4-4c80-a354-86b915a04ff8'
+    json-web-key:
+      type: object
+      properties:
+        kid:
+          type: string
+        alg:
+          type: string
+          description: 'The cryptographic algorithm family used with the key. The only allowed value is `EdDSA`. '
+          enum:
+            - EdDSA
+        use:
+          type: string
+          enum:
+            - sig
+        kty:
+          type: string
+          enum:
+            - OKP
+        crv:
+          type: string
+          enum:
+            - Ed25519
+        x:
+          type: string
+          pattern: '^[a-zA-Z0-9-_]+$'
+          description: The base64 url-encoded public key.
+      required:
+        - kid
+        - alg
+        - kty
+        - crv
+        - x
+      title: Ed25519 Public Key
+      description: A JWK representation of an Ed25519 Public Key
+      examples:
+        - kid: key-1
+          use: sig
+          kty: OKP
+          crv: Ed25519
+          x: 11qYAYKxCrfVS_7TyWQHOg7hcvPapiMlrwIaaPcHURo
+        - kid: '2022-09-02'
+          use: sig
+          kty: OKP
+          crv: Ed25519
+          x: oy0L_vTygNE4IogRyn_F5GmHXdqYVjIXkWs2jky7zsI


### PR DESCRIPTION
To replace:
https://github.com/interledger/rafiki/blob/a0302b390192f001fc4baa6bc55ae8dcfb13143a/packages/auth/src/openapi/resource-server.yaml#L117-L170