### PR TITLE
feat: add form style to pagination params

### DIFF
--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -517,11 +517,7 @@ paths:
           $ref: '#/components/responses/403'
       description: List all outgoing payments on the payment pointer
       parameters:
-        - schema:
-            $ref: '#/components/schemas/pagination'
-          in: query
-          name: pagination
-          description: Pagination parameters
+        - $ref: '#/components/parameters/pagination'
         - $ref: '#/components/parameters/signature-input'
         - $ref: '#/components/parameters/signature'
       tags:

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -324,6 +324,7 @@ paths:
           in: query
           name: pagination
           description: Pagination parameters
+          style: form
         - $ref: '#/components/parameters/signature-input'
         - $ref: '#/components/parameters/signature'
       tags:

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -319,12 +319,7 @@ paths:
           $ref: '#/components/responses/403'
       description: List all incoming payments on the payment pointer
       parameters:
-        - schema:
-            $ref: '#/components/schemas/pagination'
-          in: query
-          name: pagination
-          description: Pagination parameters
-          style: form
+        - $ref: '#/components/parameters/pagination'
         - $ref: '#/components/parameters/signature-input'
         - $ref: '#/components/parameters/signature'
       tags:
@@ -1322,6 +1317,13 @@ components:
     '403':
       description: Forbidden
   parameters:
+    pagination:
+      schema:
+        $ref: '#/components/schemas/pagination'
+      in: query
+      name: pagination
+      description: Pagination parameters
+      style: form
     id:
       name: id
       in: path


### PR DESCRIPTION
Fixes #227 
_Copied from #227 description:_

The Open Payments API doc examples prepend the `pagination` parameter when showing an example call to list outgoing or incoming payments:

<img width="781" alt="Screen Shot 2022-12-07 at 2 56 31 PM" src="https://user-images.githubusercontent.com/15069181/206198044-7bf42932-5f96-4f1e-9ac1-7d8a6f62d34d.png">

Specifically,

```sh
curl --request GET \
     --url 'https://openpayments.guide/alice/incoming-payments?pagination=first=10&cursor=uuid' \
     --header 'accept: application/json'
     
// inclusion of "pagination" is the issue here    
```

https://docs.openpayments.guide/reference/list-outgoing-payments

However, we do not use root `pagination` parameter when we parse the query parameters when we are handling `GET /(incoming | outgoing)-payments` calls in `backend`, we only look at `first` `last` `cursor` params:

https://github.com/interledger/rafiki/blob/a0302b390192f001fc4baa6bc55ae8dcfb13143a/packages/backend/src/open_payments/payment_pointer/routes.ts#L50

https://github.com/interledger/rafiki/blob/a0302b390192f001fc4baa6bc55ae8dcfb13143a/packages/backend/src/shared/pagination.ts#L9-L20


We should update Open Payments API docs to ignore `pagination` as the root key parameter for the example requests.

ie, it should be just
```sh
curl --request GET \
     --url 'https://openpayments.guide/alice/incoming-payments?first=10&cursor=uuid' \
     --header 'accept: application/json'
```