### PR TITLE
feat: adding integration workflows

### DIFF
--- a/.github/workflows/publish-integration-openapi.yaml
+++ b/.github/workflows/publish-integration-openapi.yaml
@@ -1,0 +1,23 @@
+name: OpenAPI Integration Publisher
+
+on:
+  push:
+    branches:
+      - integration
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        name: Check out repository
+
+      - uses: readmeio/rdme@7.5.0
+        name: Sync Open Payments API spec
+        with:
+          rdme: openapi resource-server.yaml --workingDirectory=openapi --key=${{ secrets.README_INTEGRATION_API_KEY }} --id=${{ secrets.README_INTEGRATION_OP_API_ID }}
+
+      - uses: readmeio/rdme@7.5.0
+        name: Sync Auth Server API spec
+        with:
+          rdme: openapi auth-server.yaml --workingDirectory=openapi --key=${{ secrets.README_INTEGRATION_API_KEY }} --id=${{ secrets.README_INTEGRATION_AUTH_API_ID }}

--- a/.github/workflows/validate-openapi.yaml
+++ b/.github/workflows/validate-openapi.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - integration
     paths:
       - openapi/**
   pull_request:


### PR DESCRIPTION
While working on https://github.com/interledger/open-payments/pull/228 I found it hard to make changes to the Open API schemas to see how they end up looking on https://docs.openpayments.guide. 

I ended up making a separate integration readme: https://open-payments-integration.readme.io.
Anytime a change is pushed to the `integration` branch, the changes will be reflected on the site.