### PR TITLE
224/mk/post quote update

### DIFF
--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -578,16 +578,19 @@ paths:
             schema:
               type: object
               additionalProperties: false
-              properties:
-                receiver:
-                  $ref: ./schemas.yaml#/components/schemas/receiver
               oneOf:
-                - receiveAmount:
-                    description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                    $ref: ./schemas.yaml#/components/schemas/amount
-                - sendAmount:
-                    description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                    $ref: ./schemas.yaml#/components/schemas/amount
+                - properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                    receiveAmount:
+                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      $ref: ./schemas.yaml#/components/schemas/amount
+                - properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                    sendAmount:
+                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -584,12 +584,12 @@ paths:
                   required:
                     - receiver
                   additionalProperties: false
-                - description: Create a quote with a fixed receive amount
+                - description: Create a quote with a fixed-receive amount
                   properties:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                     receiveAmount:
-                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      description: The maximum amount that should be paid into the receiving payment pointer.
                       $ref: ./schemas.yaml#/components/schemas/amount
                   required:
                     - receiver
@@ -600,7 +600,7 @@ paths:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                     sendAmount:
-                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      description: The maximum amount that should be sent from the sending payment pointer.
                       $ref: ./schemas.yaml#/components/schemas/amount
                   required:
                     - receiver

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -584,12 +584,12 @@ paths:
                 amount:
                   description: Possible amount types
                   oneOf:
-                    receiveAmount:
-                      description: The receiveAmount.
-                      $ref: ./schemas.yaml#/components/schemas/amount
-                    sendAmount:
-                      description: The sendAmount
-                      $ref: ./schemas.yaml#/components/schemas/amount
+                    - receiveAmount:
+                        description: The receiveAmount.
+                        $ref: ./schemas.yaml#/components/schemas/amount
+                    - sendAmount:
+                        description: The sendAmount
+                        $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -576,9 +576,8 @@ paths:
                     assetCode: USD
                     assetScale: 2
             schema:
-              type: object
               oneOf:
-                - schema:
+                - receiverWithReceiveAmount:
                     type: object
                     properties:
                       receiver:
@@ -590,7 +589,7 @@ paths:
                       - receiver
                       - receiveAmount
                     additionalProperties: false
-                - schema:
+                - receiverWithSendAmount:
                     type: object
                     properties:
                       receiver:

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -581,10 +581,11 @@ paths:
               properties:
                 receiver:
                   $ref: ./schemas.yaml#/components/schemas/receiver
-                receiveAmount:
-                  $ref: ./schemas.yaml#/components/schemas/amount
-                sendAmount:
-                  $ref: ./schemas.yaml#/components/schemas/amount
+                oneOf:
+                  receiveAmount:
+                    $ref: ./schemas.yaml#/components/schemas/amount
+                  sendAmount:
+                    $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -581,8 +581,6 @@ paths:
               properties:
                 receiver:
                   $ref: ./schemas.yaml#/components/schemas/receiver
-                amount:
-                  description: Possible amount types
               oneOf:
                 - receiveAmount:
                     description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -576,37 +576,22 @@ paths:
                     assetCode: USD
                     assetScale: 2
             schema:
+              properties:
+                receiver:
+                  $ref: ./schemas.yaml#/components/schemas/receiver
+                sendAmount:
+                  description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                  $ref: ./schemas.yaml#/components/schemas/amount
+                receiveAmount:
+                  description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                  $ref: ./schemas.yaml#/components/schemas/amount
               oneOf:
-                - description: Quote for incoming payment
-                  properties:
-                    receiver:
-                      $ref: ./schemas.yaml#/components/schemas/receiver
-                  required:
-                    - receiver
-                  additionalProperties: false
-                - description: Fixed receive quote
-                  properties:
-                    receiver:
-                      $ref: ./schemas.yaml#/components/schemas/receiver
-                    receiveAmount:
-                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                      $ref: ./schemas.yaml#/components/schemas/amount
-                  required:
-                    - receiver
-                    - receiveAmount
-                  additionalProperties: false
-                - description: Fixed send quote
-                  properties:
-                    receiver:
-                      $ref: ./schemas.yaml#/components/schemas/receiver
-                    sendAmount:
-                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                      $ref: ./schemas.yaml#/components/schemas/amount
-                  required:
+                - required:
                     - receiver
                     - sendAmount
-                  additionalProperties: false
-
+                - required:
+                    - receiver
+                    - receiveAmount
         description: |-
           A subset of the quotes schema is accepted as input to create a new quote.
 

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -577,30 +577,26 @@ paths:
                     assetScale: 2
             schema:
               oneOf:
-                - receiverWithReceiveAmount:
-                    type: object
-                    properties:
-                      receiver:
-                        $ref: ./schemas.yaml#/components/schemas/receiver
-                      receiveAmount:
-                        description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                        $ref: ./schemas.yaml#/components/schemas/amount
-                    required:
-                      - receiver
-                      - receiveAmount
-                    additionalProperties: false
-                - receiverWithSendAmount:
-                    type: object
-                    properties:
-                      receiver:
-                        $ref: ./schemas.yaml#/components/schemas/receiver
-                      sendAmount:
-                        description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                        $ref: ./schemas.yaml#/components/schemas/amount
-                    required:
-                      - receiver
-                      - sendAmount
-                    additionalProperties: false
+                - properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                    receiveAmount:
+                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      $ref: ./schemas.yaml#/components/schemas/amount
+                  required:
+                    - receiver
+                    - receiveAmount
+                  additionalProperties: false
+                - properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                    sendAmount:
+                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      $ref: ./schemas.yaml#/components/schemas/amount
+                  required:
+                    - receiver
+                    - sendAmount
+                  additionalProperties: false
 
         description: |-
           A subset of the quotes schema is accepted as input to create a new quote.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -577,14 +577,14 @@ paths:
                     assetScale: 2
             schema:
               oneOf:
-                - description: Quote for incoming payment
+                - description: Create quote for an `receiver` that is an Incoming Payment with an `incomingAmount`
                   properties:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                   required:
                     - receiver
                   additionalProperties: false
-                - description: Fixed receive quote
+                - description: Create a quote with a fixed receive amount
                   properties:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
@@ -595,7 +595,7 @@ paths:
                     - receiver
                     - receiveAmount
                   additionalProperties: false
-                - description: Fixed send quote
+                - description: Create a quote with a fixed send amount
                   properties:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -581,11 +581,15 @@ paths:
               properties:
                 receiver:
                   $ref: ./schemas.yaml#/components/schemas/receiver
-              oneOf:
-                receiveAmount:
-                  $ref: ./schemas.yaml#/components/schemas/amount
-                sendAmount:
-                  $ref: ./schemas.yaml#/components/schemas/amount
+                amount:
+                  description: Possible amount types
+                  oneOf:
+                    receiveAmount:
+                      description: The receiveAmount.
+                      $ref: ./schemas.yaml#/components/schemas/amount
+                    sendAmount:
+                      description: The sendAmount
+                      $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -577,22 +577,32 @@ paths:
                     assetScale: 2
             schema:
               type: object
-              additionalProperties: false
               oneOf:
-                - properties:
-                    receiver:
-                      $ref: ./schemas.yaml#/components/schemas/receiver
-                    receiveAmount:
-                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                      $ref: ./schemas.yaml#/components/schemas/amount
-                - properties:
-                    receiver:
-                      $ref: ./schemas.yaml#/components/schemas/receiver
-                    sendAmount:
-                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                      $ref: ./schemas.yaml#/components/schemas/amount
-              required:
-                - receiver
+                - schema:
+                    type: object
+                    properties:
+                      receiver:
+                        $ref: ./schemas.yaml#/components/schemas/receiver
+                      receiveAmount:
+                        description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                        $ref: ./schemas.yaml#/components/schemas/amount
+                    required:
+                      - receiver
+                      - receiveAmount
+                    additionalProperties: false
+                - schema:
+                    type: object
+                    properties:
+                      receiver:
+                        $ref: ./schemas.yaml#/components/schemas/receiver
+                      sendAmount:
+                        description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                        $ref: ./schemas.yaml#/components/schemas/amount
+                    required:
+                      - receiver
+                      - sendAmount
+                    additionalProperties: false
+
         description: |-
           A subset of the quotes schema is accepted as input to create a new quote.
 

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -583,13 +583,13 @@ paths:
                   $ref: ./schemas.yaml#/components/schemas/receiver
                 amount:
                   description: Possible amount types
-                  oneOf:
-                    - receiveAmount:
-                        description: The receiveAmount.
-                        $ref: ./schemas.yaml#/components/schemas/amount
-                    - sendAmount:
-                        description: The sendAmount
-                        $ref: ./schemas.yaml#/components/schemas/amount
+              oneOf:
+                - receiveAmount:
+                    description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                    $ref: ./schemas.yaml#/components/schemas/amount
+                - sendAmount:
+                    description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                    $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -582,12 +582,10 @@ paths:
                 receiver:
                   $ref: ./schemas.yaml#/components/schemas/receiver
               oneOf:
-                properties:
-                    receiveAmount: 
-                      $ref: ./schemas.yaml#/components/schemas/amount
-                properties:
-                    sendAmount: 
-                      $ref: ./schemas.yaml#/components/schemas/amount
+                receiveAmount:
+                  $ref: ./schemas.yaml#/components/schemas/amount
+                sendAmount:
+                  $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -577,7 +577,15 @@ paths:
                     assetScale: 2
             schema:
               oneOf:
-                - properties:
+                - description: Quote for incoming payment
+                  properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                  required:
+                    - receiver
+                  additionalProperties: false
+                - description: Fixed receive quote
+                  properties:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                     receiveAmount:
@@ -587,7 +595,8 @@ paths:
                     - receiver
                     - receiveAmount
                   additionalProperties: false
-                - properties:
+                - description: Fixed send quote
+                  properties:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                     sendAmount:

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -589,7 +589,7 @@ paths:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                     receiveAmount:
-                      description: The maximum amount that should be paid into the receiving payment pointer.
+                      description: The fixed amount that would be paid into the receiving payment pointer given a successful outgoing payment.
                       $ref: ./schemas.yaml#/components/schemas/amount
                   required:
                     - receiver
@@ -600,7 +600,7 @@ paths:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                     sendAmount:
-                      description: The maximum amount that should be sent from the sending payment pointer.
+                      description: The fixed amount that would be sent from the sending payment pointer given a successful outgoing payment.
                       $ref: ./schemas.yaml#/components/schemas/amount
                   required:
                     - receiver

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -576,22 +576,37 @@ paths:
                     assetCode: USD
                     assetScale: 2
             schema:
-              properties:
-                receiver:
-                  $ref: ./schemas.yaml#/components/schemas/receiver
-                sendAmount:
-                  description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                  $ref: ./schemas.yaml#/components/schemas/amount
-                receiveAmount:
-                  description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-                  $ref: ./schemas.yaml#/components/schemas/amount
               oneOf:
-                - required:
+                - description: Quote for incoming payment
+                  properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                  required:
                     - receiver
-                    - sendAmount
-                - required:
+                  additionalProperties: false
+                - description: Fixed receive quote
+                  properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                    receiveAmount:
+                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      $ref: ./schemas.yaml#/components/schemas/amount
+                  required:
                     - receiver
                     - receiveAmount
+                  additionalProperties: false
+                - description: Fixed send quote
+                  properties:
+                    receiver:
+                      $ref: ./schemas.yaml#/components/schemas/receiver
+                    sendAmount:
+                      description: All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
+                      $ref: ./schemas.yaml#/components/schemas/amount
+                  required:
+                    - receiver
+                    - sendAmount
+                  additionalProperties: false
+
         description: |-
           A subset of the quotes schema is accepted as input to create a new quote.
 

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -581,11 +581,11 @@ paths:
               properties:
                 receiver:
                   $ref: ./schemas.yaml#/components/schemas/receiver
-                oneOf:
-                  receiveAmount:
-                    $ref: ./schemas.yaml#/components/schemas/amount
-                  sendAmount:
-                    $ref: ./schemas.yaml#/components/schemas/amount
+              oneOf:
+                properties:
+                    receiveAmount: $ref: ./schemas.yaml#/components/schemas/amount
+                properties:
+                    sendAmount: $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -583,9 +583,11 @@ paths:
                   $ref: ./schemas.yaml#/components/schemas/receiver
               oneOf:
                 properties:
-                    receiveAmount: $ref: ./schemas.yaml#/components/schemas/amount
+                    receiveAmount: 
+                      $ref: ./schemas.yaml#/components/schemas/amount
                 properties:
-                    sendAmount: $ref: ./schemas.yaml#/components/schemas/amount
+                    sendAmount: 
+                      $ref: ./schemas.yaml#/components/schemas/amount
               required:
                 - receiver
         description: |-


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

During quote creation, we should either expect
a) just the `receiver`
b) `receiver` & `receiveAmount`
c) `receiver` & `sendAmount`

I wanted to enforce this at the API level, as currently, `receiver` is a required property, but `receiveAmount` and `sendAmount` are just optional properties.

After some fiddling around, I found the best way to enforce this was providing 3 possible `oneOf` schemas for the quote creation request body.

https://open-payments-integration.readme.io/reference/create-quote



<!--
Provide a succinct description of what this pull request entails.
-->

## Context

Fixes #224 
