### PR TITLE
feat: add unauthorized response to grant initiation

### DIFF
--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -74,6 +74,8 @@ paths:
                       uri: 'https://openpayments.guide/auth/continue/4CF492MLVMSW9MKMXKHQ'
         '400':
           description: Bad Request
+        '401':
+          description: Unauthorized
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
- Adds `401` as a potential response from the grant initiation endpoint.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
Because this endpoint uses httpsig validation, the spec should account for `Unauthorized` responses.
