### PR TITLE
chore: make startCursor and endCursor optional

### DIFF
--- a/.changeset/metal-panthers-fix.md
+++ b/.changeset/metal-panthers-fix.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Optional startCursor & endCursor for pagination

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -41,7 +41,7 @@ jobs:
         id: verify-changed-files
         with:
           files: |
-            **/generated/*.ts
+            packages/open-payments/**/generated/*.ts
       - name: Fail if missing new open-payments types
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: exit 1

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -36,12 +36,13 @@ jobs:
       - uses: ./.github/workflows/env-setup
       - name: Generate open-payments types
         run: pnpm --filter open-payments generate:types
-      - name: Check for missing new open-payments types
+      - name: Check for newly generated open-payments types
         uses: tj-actions/verify-changed-files@v14
         id: verify-changed-files
         with:
           files: |
             **/generated/*.ts
+      - name: Fail if missing generated open-payments types
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: exit 1
       - run: pnpm --filter open-payments build

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -34,15 +34,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/env-setup
-      - name: Generate open-payments types
+      - name: Check generated open-payments types
         run: pnpm --filter open-payments generate:types
-      - name: verify changed files
         uses: tj-actions/verify-changed-files@v14
         id: verify-changed-files
         with:
           files: |
             **/generated/*.ts
-      - name: Fail if new types were generated
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: exit 1
       - run: pnpm --filter open-payments build

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -42,7 +42,7 @@ jobs:
         with:
           files: |
             **/generated/*.ts
-      - name: Fail if missing generated open-payments types
+      - name: Fail if missing new open-payments types
         if: steps.verify-changed-files.outputs.files_changed == 'true'
         run: exit 1
       - run: pnpm --filter open-payments build

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -34,6 +34,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/env-setup
+      - name: Generate open-payments types
+        run: pnpm --filter open-payments generate:types
+      - name: verify changed files
+        uses: tj-actions/verify-changed-files@v14
+        id: verify-changed-files
+        with:
+          files: |
+            **/generated/*.ts
+      - name: Fail if new types were generated
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        run: exit 1
       - run: pnpm --filter open-payments build
       - run: pnpm --filter open-payments test
 

--- a/.github/workflows/lint-test-build.yaml
+++ b/.github/workflows/lint-test-build.yaml
@@ -34,8 +34,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: ./.github/workflows/env-setup
-      - name: Check generated open-payments types
+      - name: Generate open-payments types
         run: pnpm --filter open-payments generate:types
+      - name: Check for missing new open-payments types
         uses: tj-actions/verify-changed-files@v14
         id: verify-changed-files
         with:

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1239,8 +1239,6 @@ components:
           type: boolean
           description: Describes whether the data set has previous entries.
       required:
-        - startCursor
-        - endCursor
         - hasNextPage
         - hasPreviousPage
       additionalProperties: false

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -294,9 +294,9 @@ export interface components {
     };
     "page-info": {
       /** @description Cursor corresponding to the first element in the result array. */
-      startCursor?: string;
+      startCursor: string;
       /** @description Cursor corresponding to the last element in the result array. */
-      endCursor?: string;
+      endCursor: string;
       /** @description Describes whether the data set has further entries. */
       hasNextPage: boolean;
       /** @description Describes whether the data set has previous entries. */

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -294,9 +294,9 @@ export interface components {
     };
     "page-info": {
       /** @description Cursor corresponding to the first element in the result array. */
-      startCursor: string;
+      startCursor?: string;
       /** @description Cursor corresponding to the last element in the result array. */
-      endCursor: string;
+      endCursor?: string;
       /** @description Describes whether the data set has further entries. */
       hasNextPage: boolean;
       /** @description Describes whether the data set has previous entries. */


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
- Making `startCursor` and `endCursor` optional in the resource server spec for pagination responses.
- Adding CI check for missing generated types in the open-payments client

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
- Fixes #191 

When there are no results, it makes sense for `startCursor` and `endCursor` to be nullable:
- https://github.com/interledger/open-payments/issues/191#issuecomment-1579003465

This is actually causing an error in Rafiki when making Open Payments requests to list incoming/outgoing payments, and there are no results.

See the new changes here: https://open-payments-integration.readme.io/v1.1/reference/list-incoming-payments

