### PR TITLE
feat: add  metadata field to payments

### DIFF
--- a/.changeset/khaki-spies-tan.md
+++ b/.changeset/khaki-spies-tan.md
@@ -1,6 +1,5 @@
 ---
 '@interledger/open-payments': minor
-'@interledger/openapi': minor
 ---
 
 Added metadata field to payments

--- a/.changeset/khaki-spies-tan.md
+++ b/.changeset/khaki-spies-tan.md
@@ -1,0 +1,6 @@
+---
+'@interledger/open-payments': minor
+'@interledger/openapi': minor
+---
+
+Added metadata field to payments

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -168,7 +168,7 @@ paths:
                     completed: false
                     expiresAt: '2022-02-03T23:20:50.52Z'
                     externalRef: INV2022-02-0137
-                    metadata: '{"externalRef": "INV2022-02-0137"}'
+                    metadata: { externalRef: 'INV2022-02-0137' }
                     ilpStreamConnection:
                       id: 'https://openpayments.guide/connections/ff394f02-7b7b-45e2-b645-51d04e7c345c'
                       ilpAddress: g.ilp.iwuyge987y.98y08y
@@ -214,7 +214,7 @@ paths:
                     assetCode: USD
                     assetScale: 2
                   externalRef: INV2022-02-0137
-                  metadata: '{"externalRef": "INV2022-02-0137"}'
+                  metadata: { externalRef: 'INV2022-02-0137' }
         description: |-
           A subset of the incoming payments schema is accepted as input to create a new incoming payment.
 
@@ -277,7 +277,11 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
                         externalRef: Coffee w/ Mo on 10 March 22
-                        metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
+                        metadata:
+                          {
+                            description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
+                            externalRef: 'Coffee w/ Mo on 10 March 22'
+                          }
                         completed: true
                       - id: 'https://openpayments.guide/alice/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
                         paymentPointer: 'https://openpayments.guide/alice/'
@@ -328,7 +332,11 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
                         externalRef: Coffee w/ Mo on 10 March 22
-                        metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
+                        metadata:
+                          {
+                            description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
+                            externalRef: 'Coffee w/ Mo on 10 March 22'
+                          }
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -389,7 +397,7 @@ paths:
                 value:
                   quoteId: 'https://openpayments.guide/alice/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
                   externalRef: INV2022-02-0137
-                  metadata: '{"externalRef": "INV2022-02-0137"}'
+                  metadata: { externalRef: 'INV2022-02-0137' }
             schema:
               type: object
               properties:
@@ -469,7 +477,11 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: APlusVideo subscription
                         externalRef: 'customer: 847458475'
-                        metadata: '{"description": "APlusVideo subscription", "externalRef": "customer: 847458475"}'
+                        metadata:
+                          {
+                            description: 'APlusVideo subscription',
+                            externalRef: 'customer: 847458475'
+                          }
                       - id: 'https://openpayments.guide/alice/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
@@ -490,7 +502,11 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: Thank you for your purchase at ShoeShop!
                         externalRef: INV2022-8943756
-                        metadata: '{"description": "Thank you for your purchase at ShoeShop!", "externalRef": "INV2022-8943756"}'
+                        metadata:
+                          {
+                            description: 'Thank you for your purchase at ShoeShop!',
+                            externalRef: 'INV2022-8943756'
+                          }
                 backward pagination:
                   value:
                     pagination:
@@ -519,7 +535,11 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: Thank you for your purchase at ShoeShop!
                         externalRef: INV2022-8943756
-                        metadata: '{"description": "Thank you for your purchase at ShoeShop!", "externalRef": "INV2022-8943756"}'
+                        metadata:
+                          {
+                            description: 'Thank you for your purchase at ShoeShop!',
+                            externalRef: 'INV2022-8943756'
+                          }
                       - id: 'https://openpayments.guide/alice/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
@@ -540,7 +560,11 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: APlusVideo subscription
                         externalRef: 'customer: 847458475'
-                        metadata: '{"description": "APlusVideo subscription", "externalRef": "customer: 847458475"}'
+                        metadata:
+                          {
+                            description: 'APlusVideo subscription',
+                            externalRef: 'customer: 847458475'
+                          }
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -681,7 +705,11 @@ paths:
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     description: Thanks for the flowers!
                     externalRef: INV-12876
-                    metadata: '{"description": "Thanks for the flowers!", "externalRef": "INV-12876"}'
+                    metadata:
+                      {
+                        description: 'Thanks for the flowers!',
+                        externalRef: 'INV-12876'
+                      }
                     ilpStreamConnection:
                       id: 'https://openpayments.guide/connections/4a1b0150-db73-49e8-8713-628baa4a17ff'
                       ilpAddress: g.ilp.iwuyge987y.98y08y
@@ -733,7 +761,11 @@ paths:
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
                     externalRef: Coffee w/ Mo on 10 March 22
-                    metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
+                    metadata:
+                      {
+                        description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
+                        externalRef: 'Coffee w/ Mo on 10 March 2'
+                      }
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -785,7 +817,11 @@ paths:
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     description: Thanks for the flowers!
                     externalRef: INV-12876
-                    metadata: '{"description": "Thanks for the flowers!", "externalRef": "INV-12876"}'
+                    metadata:
+                      {
+                        description: 'Thanks for the flowers!',
+                        externalRef: 'INV-12876'
+                      }
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -954,7 +990,11 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
           externalRef: Coffee w/ Mo on 10 March 22
-          metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
+          metadata:
+            {
+              description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
+              externalRef: 'Coffee w/ Mo on 10 March 22'
+            }
         - id: 'https://openpayments.guide/alice/incoming-payments/456da9d5-c9a4-4c80-a354-86b915a04ff8'
           paymentPointer: 'https://openpayments.guide/alice/'
           incomingAmount:
@@ -1039,7 +1079,11 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
           externalRef: Coffee w/ Mo on 10 March 22
-          metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
+          metadata:
+            {
+              description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
+              externalRef: 'Coffee w/ Mo on 10 March 22'
+            }
           ilpStreamConnection:
             id: 'https://openpayments.guide/connections/032da9d5-c9a4-4c80-a354-86b915a04ff8'
             ilpApddress: g.ilp.iwuyge987y.98y08y
@@ -1105,7 +1149,11 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: APlusVideo subscription
           externalRef: 'customer: 847458475'
-          metadata: '{"description": "APlusVideo subscription", "externalRef": "customer: 847458475"}'
+          metadata:
+            {
+              description: 'APlusVideo subscription',
+              externalRef: 'customer: 847458475'
+            }
         - id: 'https://openpayments.guide/alice/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
           paymentPointer: 'https://openpayments.guide/alice/'
           failed: false
@@ -1122,7 +1170,11 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: Thank you for your purchase at ShoeShop!
           externalRef: INV2022-8943756
-          metadata: '{"description": "Thank you for your purchase at ShoeShop!", "externalRef": "INV2022-8943756"}'
+          metadata:
+            {
+              description: 'Thank you for your purchase at ShoeShop!',
+              externalRef: 'INV2022-8943756'
+            }
       properties:
         id:
           type: string

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -198,9 +198,11 @@ paths:
                 description:
                   type: string
                   description: Human readable description of the incoming payment that will be visible to the account holder.
+                  deprecated: true
                 externalRef:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+                  deprecated: true
                 metadata:
                   type: object
                   additionalProperties: true
@@ -408,9 +410,11 @@ paths:
                 description:
                   type: string
                   description: Human readable description of the outgoing payment that will be visible to the account holder and shared with the receiver.
+                  deprecated: true
                 externalRef:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+                  deprecated: true
                 metadata:
                   type: object
                   additionalProperties: true
@@ -1036,9 +1040,11 @@ components:
         description:
           type: string
           description: Human readable description of the incoming payment that will be visible to the account holder.
+          deprecated: true
         externalRef:
           type: string
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number.
+          deprecated: true
         metadata:
           type: object
           additionalProperties: true
@@ -1210,9 +1216,11 @@ components:
         description:
           type: string
           description: Human readable description of the outgoing payment that will be visible to the account holder and shared with the receiver.
+          deprecated: true
         externalRef:
           type: string
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+          deprecated: true
         metadata:
           type: object
           additionalProperties: true

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -202,7 +202,8 @@ paths:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
                 metadata:
-                  type: string
+                  type: object
+                  additionalProperties: true
                   description: Additional metadata associated with the incoming payment. (Optional)
               additionalProperties: false
             examples:
@@ -403,7 +404,8 @@ paths:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
                 metadata:
-                  type: string
+                  type: object
+                  additionalProperties: true
                   description: Additional metadata associated with the outgoing payment. (Optional)
               required:
                 - quoteId
@@ -998,7 +1000,8 @@ components:
           type: string
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number.
         metadata:
-          type: string
+          type: object
+          additionalProperties: true
           description: Additional metadata associated with the incoming payment. (Optional)
         createdAt:
           type: string
@@ -1159,7 +1162,8 @@ components:
           type: string
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
         metadata:
-          type: string
+          type: object
+          additionalProperties: true
           description: Additional metadata associated with the outgoing payment. (Optional)
         createdAt:
           type: string

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -203,8 +203,7 @@ paths:
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
                 metadata:
                   type: string
-                  format: json
-                  description: Additional metadata associated with the incoming payment, represented as a JSON string. (Optional)
+                  description: Additional metadata associated with the incoming payment. (Optional)
               additionalProperties: false
             examples:
               Create incoming payment for $25 to pay invoice INV2022-02-0137:
@@ -405,8 +404,7 @@ paths:
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
                 metadata:
                   type: string
-                  format: json
-                  description: Additional metadata associated with the outgoing payment, represented as a JSON string. (Optional)
+                  description: Additional metadata associated with the outgoing payment. (Optional)
               required:
                 - quoteId
               additionalProperties: false
@@ -1001,8 +999,7 @@ components:
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number.
         metadata:
           type: string
-          format: json
-          description: Additional metadata associated with the incoming payment, represented as a JSON string. (Optional)
+          description: Additional metadata associated with the incoming payment. (Optional)
         createdAt:
           type: string
           format: date-time
@@ -1163,8 +1160,7 @@ components:
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
         metadata:
           type: string
-          format: json
-          description: Additional metadata associated with the outgoing payment, represented as a JSON string. (Optional)
+          description: Additional metadata associated with the outgoing payment. (Optional)
         createdAt:
           type: string
           format: date-time

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1164,7 +1164,7 @@ components:
         metadata:
           type: string
           format: json
-          description: Additional metadata associated with the incoming payment, represented as a JSON string. (Optional)
+          description: Additional metadata associated with the outgoing payment, represented as a JSON string. (Optional)
         createdAt:
           type: string
           format: date-time

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -168,6 +168,7 @@ paths:
                     completed: false
                     expiresAt: '2022-02-03T23:20:50.52Z'
                     externalRef: INV2022-02-0137
+                    metadata: '{"externalRef": "INV2022-02-0137"}'
                     ilpStreamConnection:
                       id: 'https://openpayments.guide/connections/ff394f02-7b7b-45e2-b645-51d04e7c345c'
                       ilpAddress: g.ilp.iwuyge987y.98y08y
@@ -200,6 +201,10 @@ paths:
                 externalRef:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+                metadata:
+                  type: string
+                  format: json
+                  description: Additional metadata associated with the incoming payment, represented as a JSON string. (Optional)
               additionalProperties: false
             examples:
               Create incoming payment for $25 to pay invoice INV2022-02-0137:
@@ -209,6 +214,7 @@ paths:
                     assetCode: USD
                     assetScale: 2
                   externalRef: INV2022-02-0137
+                  metadata: '{"externalRef": "INV2022-02-0137"}'
         description: |-
           A subset of the incoming payments schema is accepted as input to create a new incoming payment.
 
@@ -271,6 +277,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
                         externalRef: Coffee w/ Mo on 10 March 22
+                        metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
                         completed: true
                       - id: 'https://openpayments.guide/alice/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
                         paymentPointer: 'https://openpayments.guide/alice/'
@@ -321,6 +328,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
                         externalRef: Coffee w/ Mo on 10 March 22
+                        metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -381,6 +389,7 @@ paths:
                 value:
                   quoteId: 'https://openpayments.guide/alice/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
                   externalRef: INV2022-02-0137
+                  metadata: '{"externalRef": "INV2022-02-0137"}'
             schema:
               type: object
               properties:
@@ -394,6 +403,10 @@ paths:
                 externalRef:
                   type: string
                   description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+                metadata:
+                  type: string
+                  format: json
+                  description: Additional metadata associated with the outgoing payment, represented as a JSON string. (Optional)
               required:
                 - quoteId
               additionalProperties: false
@@ -456,6 +469,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: APlusVideo subscription
                         externalRef: 'customer: 847458475'
+                        metadata: '{"description": "APlusVideo subscription", "externalRef": "customer: 847458475"}'
                       - id: 'https://openpayments.guide/alice/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
@@ -476,6 +490,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: Thank you for your purchase at ShoeShop!
                         externalRef: INV2022-8943756
+                        metadata: '{"description": "Thank you for your purchase at ShoeShop!", "externalRef": "INV2022-8943756"}'
                 backward pagination:
                   value:
                     pagination:
@@ -504,6 +519,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: Thank you for your purchase at ShoeShop!
                         externalRef: INV2022-8943756
+                        metadata: '{"description": "Thank you for your purchase at ShoeShop!", "externalRef": "INV2022-8943756"}'
                       - id: 'https://openpayments.guide/alice/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
@@ -524,6 +540,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         description: APlusVideo subscription
                         externalRef: 'customer: 847458475'
+                        metadata: '{"description": "APlusVideo subscription", "externalRef": "customer: 847458475"}'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -664,6 +681,7 @@ paths:
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     description: Thanks for the flowers!
                     externalRef: INV-12876
+                    metadata: '{"description": "Thanks for the flowers!", "externalRef": "INV-12876"}'
                     ilpStreamConnection:
                       id: 'https://openpayments.guide/connections/4a1b0150-db73-49e8-8713-628baa4a17ff'
                       ilpAddress: g.ilp.iwuyge987y.98y08y
@@ -715,6 +733,7 @@ paths:
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
                     externalRef: Coffee w/ Mo on 10 March 22
+                    metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -766,6 +785,7 @@ paths:
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     description: Thanks for the flowers!
                     externalRef: INV-12876
+                    metadata: '{"description": "Thanks for the flowers!", "externalRef": "INV-12876"}'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -934,6 +954,7 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
           externalRef: Coffee w/ Mo on 10 March 22
+          metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
         - id: 'https://openpayments.guide/alice/incoming-payments/456da9d5-c9a4-4c80-a354-86b915a04ff8'
           paymentPointer: 'https://openpayments.guide/alice/'
           incomingAmount:
@@ -978,6 +999,10 @@ components:
         externalRef:
           type: string
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number.
+        metadata:
+          type: string
+          format: json
+          description: Additional metadata associated with the incoming payment, represented as a JSON string. (Optional)
         createdAt:
           type: string
           format: date-time
@@ -1014,6 +1039,7 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
           externalRef: Coffee w/ Mo on 10 March 22
+          metadata: '{"description": "Hi Mo, this is for the cappuccino I bought for you the other day.", "externalRef": "Coffee w/ Mo on 10 March 22"}'
           ilpStreamConnection:
             id: 'https://openpayments.guide/connections/032da9d5-c9a4-4c80-a354-86b915a04ff8'
             ilpApddress: g.ilp.iwuyge987y.98y08y
@@ -1079,6 +1105,7 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: APlusVideo subscription
           externalRef: 'customer: 847458475'
+          metadata: '{"description": "APlusVideo subscription", "externalRef": "customer: 847458475"}'
         - id: 'https://openpayments.guide/alice/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
           paymentPointer: 'https://openpayments.guide/alice/'
           failed: false
@@ -1095,6 +1122,7 @@ components:
           updatedAt: '2022-04-01T10:24:36.11Z'
           description: Thank you for your purchase at ShoeShop!
           externalRef: INV2022-8943756
+          metadata: '{"description": "Thank you for your purchase at ShoeShop!", "externalRef": "INV2022-8943756"}'
       properties:
         id:
           type: string
@@ -1133,6 +1161,10 @@ components:
         externalRef:
           type: string
           description: A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+        metadata:
+          type: string
+          format: json
+          description: Additional metadata associated with the incoming payment, represented as a JSON string. (Optional)
         createdAt:
           type: string
           format: date-time

--- a/packages/open-payments/README.md
+++ b/packages/open-payments/README.md
@@ -146,6 +146,7 @@ const incomingPayment = await client.incomingPayment.create(
     },
     description: 'Purchase at Shoe Shop',
     externalRef: '#INV2022-8363828'
+    metadata: '{"externalRef": "#INV2022-8363828", "description": "Purchase at Shoe Shop"}',
   }
 )
 ```

--- a/packages/open-payments/src/client/incoming-payment.test.ts
+++ b/packages/open-payments/src/client/incoming-payment.test.ts
@@ -125,22 +125,24 @@ describe('incoming-payment', (): void => {
 
   describe('createIncomingPayment', (): void => {
     test.each`
-      incomingAmount                                      | expiresAt                                      | description  | externalRef
-      ${undefined}                                        | ${undefined}                                   | ${undefined} | ${undefined}
-      ${{ assetCode: 'USD', assetScale: 2, value: '10' }} | ${new Date(Date.now() + 60_000).toISOString()} | ${'Invoice'} | ${'#INV-1'}
+      incomingAmount                                      | expiresAt                                      | description  | externalRef  | metadata
+      ${undefined}                                        | ${undefined}                                   | ${undefined} | ${undefined} | ${undefined}
+      ${{ assetCode: 'USD', assetScale: 2, value: '10' }} | ${new Date(Date.now() + 60_000).toISOString()} | ${'Invoice'} | ${'#INV-1'}  | ${'{"description": "Invoice", "externalRef": "#INV-1"}'}
     `(
       'returns the incoming payment on success',
       async ({
         incomingAmount,
         expiresAt,
         description,
-        externalRef
+        externalRef,
+        metadata
       }): Promise<void> => {
         const incomingPayment = mockIncomingPaymentWithConnection({
           incomingAmount,
           expiresAt,
           description,
-          externalRef
+          externalRef,
+          metadata
         })
 
         const scope = nock(paymentPointer)
@@ -155,7 +157,8 @@ describe('incoming-payment', (): void => {
             incomingAmount,
             expiresAt,
             description,
-            externalRef
+            externalRef,
+            metadata
           }
         )
 

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -260,16 +260,17 @@ describe('outgoing-payment', (): void => {
     const quoteId = `${paymentPointer}/quotes/${uuid()}`
 
     test.each`
-      description           | externalRef
-      ${'Some description'} | ${'#INV-1'}
-      ${undefined}          | ${undefined}
+      description           | externalRef  | metadata
+      ${'Some description'} | ${'#INV-1'}  | ${'{"description": "Some description", "externalRef": "#INV-1"}'}
+      ${undefined}          | ${undefined} | ${undefined}
     `(
       'creates outgoing payment',
-      async ({ description, externalRef }): Promise<void> => {
+      async ({ description, externalRef, metadata }): Promise<void> => {
         const outgoingPayment = mockOutgoingPayment({
           quoteId,
           description,
-          externalRef
+          externalRef,
+          metadata
         })
 
         const scope = nock(paymentPointer)
@@ -286,7 +287,8 @@ describe('outgoing-payment', (): void => {
           {
             quoteId,
             description,
-            externalRef
+            externalRef,
+            metadata
           }
         )
         expect(result).toEqual(outgoingPayment)

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -192,6 +192,8 @@ export interface components {
       description?: string;
       /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. */
       externalRef?: string;
+      /** @description Additional metadata associated with the incoming payment, represented as a JSON string. (Optional) */
+      metadata?: string;
       /**
        * Format: date-time
        * @description The date and time when the incoming payment was created.
@@ -255,6 +257,8 @@ export interface components {
       description?: string;
       /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
       externalRef?: string;
+      /** @description Additional metadata associated with the incoming payment, represented as a JSON string. (Optional) */
+      metadata?: string;
       /**
        * Format: date-time
        * @description The date and time when the outgoing payment was created.
@@ -482,6 +486,8 @@ export interface operations {
           description?: string;
           /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
           externalRef?: string;
+          /** @description Additional metadata associated with the incoming payment, represented as a JSON string. (Optional) */
+          metadata?: string;
         };
       };
     };
@@ -559,6 +565,8 @@ export interface operations {
           description?: string;
           /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
           externalRef?: string;
+          /** @description Additional metadata associated with the outgoing payment, represented as a JSON string. (Optional) */
+          metadata?: string;
         };
       };
     };

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -188,9 +188,15 @@ export interface components {
        * @description The date and time when payments under this incoming payment will no longer be accepted.
        */
       expiresAt?: string;
-      /** @description Human readable description of the incoming payment that will be visible to the account holder. */
+      /**
+       * @deprecated
+       * @description Human readable description of the incoming payment that will be visible to the account holder.
+       */
       description?: string;
-      /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. */
+      /**
+       * @deprecated
+       * @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number.
+       */
       externalRef?: string;
       /** @description Additional metadata associated with the incoming payment. (Optional) */
       metadata?: { [key: string]: unknown };
@@ -253,9 +259,15 @@ export interface components {
       sendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that has been sent under this outgoing payment. */
       sentAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description Human readable description of the outgoing payment that will be visible to the account holder and shared with the receiver. */
+      /**
+       * @deprecated
+       * @description Human readable description of the outgoing payment that will be visible to the account holder and shared with the receiver.
+       */
       description?: string;
-      /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
+      /**
+       * @deprecated
+       * @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+       */
       externalRef?: string;
       /** @description Additional metadata associated with the outgoing payment. (Optional) */
       metadata?: { [key: string]: unknown };
@@ -482,9 +494,15 @@ export interface operations {
            * @description The date and time when payments into the incoming payment must no longer be accepted.
            */
           expiresAt?: string;
-          /** @description Human readable description of the incoming payment that will be visible to the account holder. */
+          /**
+           * @deprecated
+           * @description Human readable description of the incoming payment that will be visible to the account holder.
+           */
           description?: string;
-          /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
+          /**
+           * @deprecated
+           * @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+           */
           externalRef?: string;
           /** @description Additional metadata associated with the incoming payment. (Optional) */
           metadata?: { [key: string]: unknown };
@@ -561,9 +579,15 @@ export interface operations {
            * @description The URL of the quote defining this payment's amounts.
            */
           quoteId: string;
-          /** @description Human readable description of the outgoing payment that will be visible to the account holder and shared with the receiver. */
+          /**
+           * @deprecated
+           * @description Human readable description of the outgoing payment that will be visible to the account holder and shared with the receiver.
+           */
           description?: string;
-          /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
+          /**
+           * @deprecated
+           * @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional)
+           */
           externalRef?: string;
           /** @description Additional metadata associated with the outgoing payment. (Optional) */
           metadata?: { [key: string]: unknown };

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -193,7 +193,7 @@ export interface components {
       /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. */
       externalRef?: string;
       /** @description Additional metadata associated with the incoming payment. (Optional) */
-      metadata?: string;
+      metadata?: { [key: string]: unknown };
       /**
        * Format: date-time
        * @description The date and time when the incoming payment was created.
@@ -258,7 +258,7 @@ export interface components {
       /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
       externalRef?: string;
       /** @description Additional metadata associated with the outgoing payment. (Optional) */
-      metadata?: string;
+      metadata?: { [key: string]: unknown };
       /**
        * Format: date-time
        * @description The date and time when the outgoing payment was created.
@@ -487,7 +487,7 @@ export interface operations {
           /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
           externalRef?: string;
           /** @description Additional metadata associated with the incoming payment. (Optional) */
-          metadata?: string;
+          metadata?: { [key: string]: unknown };
         };
       };
     };
@@ -566,7 +566,7 @@ export interface operations {
           /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
           externalRef?: string;
           /** @description Additional metadata associated with the outgoing payment. (Optional) */
-          metadata?: string;
+          metadata?: { [key: string]: unknown };
         };
       };
     };

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -192,7 +192,7 @@ export interface components {
       description?: string;
       /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. */
       externalRef?: string;
-      /** @description Additional metadata associated with the incoming payment, represented as a JSON string. (Optional) */
+      /** @description Additional metadata associated with the incoming payment. (Optional) */
       metadata?: string;
       /**
        * Format: date-time
@@ -257,7 +257,7 @@ export interface components {
       description?: string;
       /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
       externalRef?: string;
-      /** @description Additional metadata associated with the incoming payment, represented as a JSON string. (Optional) */
+      /** @description Additional metadata associated with the outgoing payment. (Optional) */
       metadata?: string;
       /**
        * Format: date-time
@@ -486,7 +486,7 @@ export interface operations {
           description?: string;
           /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
           externalRef?: string;
-          /** @description Additional metadata associated with the incoming payment, represented as a JSON string. (Optional) */
+          /** @description Additional metadata associated with the incoming payment. (Optional) */
           metadata?: string;
         };
       };
@@ -565,7 +565,7 @@ export interface operations {
           description?: string;
           /** @description A reference that can be used by external systems to reconcile this payment with their systems. E.g. An invoice number. (Optional) */
           externalRef?: string;
-          /** @description Additional metadata associated with the outgoing payment, represented as a JSON string. (Optional) */
+          /** @description Additional metadata associated with the outgoing payment. (Optional) */
           metadata?: string;
         };
       };

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -173,6 +173,7 @@ export const mockOutgoingPayment = (
   receiver: uuid(),
   description: 'some description',
   externalRef: 'INV #1',
+  metadata: '{"externalRef": "INV #1", "description": "some description"}',
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   ...overrides

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -173,7 +173,7 @@ export const mockOutgoingPayment = (
   receiver: uuid(),
   description: 'some description',
   externalRef: 'INV #1',
-  metadata: '{"externalRef": "INV #1", "description": "some description"}',
+  metadata: { externalRef: 'INV #1', description: 'some description' },
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
   ...overrides


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request
- adds `metadata` field to incoming/outgoing payment routes
<!--
Provide a succinct description of what this pull request entails.
-->

## Context

First of several PRs for #221 (add metadata to spec, implement metadata field in rafiki, remove `description`/`externalRef`)

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
