### PR TITLE
feat: add properties for quoting

### DIFF
--- a/.changeset/tender-ravens-breathe.md
+++ b/.changeset/tender-ravens-breathe.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Adding properties for new quoting mechanism

--- a/.changeset/tender-ravens-breathe.md
+++ b/.changeset/tender-ravens-breathe.md
@@ -1,5 +1,5 @@
 ---
-'@interledger/open-payments': minor
+'@interledger/open-payments': major
 ---
 
 Adding properties for new quoting mechanism

--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -112,7 +112,7 @@ paths:
                         limits:
                           receiver: 'https://openpayments.guide/connections/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                           interval: 'R12/2019-08-24T14:15:22Z/P1M'
-                          sendAmount:
+                          debitAmount:
                             value: '500'
                             assetCode: USD
                             assetScale: 2
@@ -180,7 +180,7 @@ paths:
                           limits:
                             receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
                             interval: 'R12/2019-08-24T14:15:22Z/P1M'
-                            sendAmount:
+                            debitAmount:
                               value: '500'
                               assetCode: USD
                               assetScale: 2
@@ -275,7 +275,7 @@ paths:
                           limits:
                             interval: 'R12/2019-08-24T14:15:22Z/P1M'
                             receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
-                            sendAmount:
+                            debitAmount:
                               value: '500'
                               assetCode: USD
                               assetScale: 2
@@ -515,7 +515,7 @@ components:
       properties:
         receiver:
           $ref: './schemas.yaml#/components/schemas/receiver'
-        sendAmount:
+        debitAmount:
           $ref: './schemas.yaml#/components/schemas/amount'
         receiveAmount:
           $ref: './schemas.yaml#/components/schemas/amount'
@@ -526,7 +526,7 @@ components:
             required:
               - interval
         - required:
-            - sendAmount
+            - debitAmount
         - required:
             - receiveAmount
   securitySchemes:

--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -516,8 +516,10 @@ components:
         receiver:
           $ref: './schemas.yaml#/components/schemas/receiver'
         debitAmount:
+          description: 'All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.'
           $ref: './schemas.yaml#/components/schemas/amount'
         receiveAmount:
+          description: 'All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.'
           $ref: './schemas.yaml#/components/schemas/amount'
         interval:
           $ref: '#/components/schemas/interval'

--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Open Payments Authorization Server
-  version: '1.0'
+  version: '1.1'
   license:
     name: Apache 2.0
     identifier: Apache-2.0

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -199,9 +199,6 @@ paths:
                 metadata:
                   type: object
                   description: Additional metadata associated with the incoming payment. (Optional)
-                feeStructure:
-                  type: boolean
-                  description: Request receiving fee structure
             examples:
               Create incoming payment for $25 to pay invoice INV2022-02-0137:
                 value:
@@ -211,7 +208,6 @@ paths:
                     assetScale: 2
                   metadata:
                     externalRef: INV2022-02-0137
-                  feeStructure: true
         description: |-
           A subset of the incoming payments schema is accepted as input to create a new incoming payment.
 
@@ -361,7 +357,7 @@ paths:
                     paymentPointer: 'https://openpayments.guide/alice/'
                     failed: false
                     receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
-                    maxSendAmount:
+                    debitAmount:
                       value: '2600'
                       assetCode: USD
                       assetScale: 2
@@ -373,15 +369,6 @@ paths:
                       value: '0'
                       assetCode: USD
                       assetScale: 2
-                    fees:
-                      sendFeeAmount:
-                        value: '100'
-                        assetCode: USD
-                        assetScale: 2
-                      receiveFeeAmount:
-                        value: '0'
-                        assetCode: USD
-                        assetScale: 2
                     metadata:
                       description: Thank you for the shoes.
                     createdAt: '2022-03-12T23:20:50.52Z'
@@ -460,7 +447,7 @@ paths:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
-                        maxSendAmount:
+                        debitAmount:
                           value: '2600'
                           assetCode: USD
                           assetScale: 2
@@ -468,15 +455,6 @@ paths:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
-                        fees:
-                          sendFeeAmount:
-                            value: '100'
-                            assetCode: USD
-                            assetScale: 2
-                          receiveFeeAmount:
-                            value: '0'
-                            assetCode: USD
-                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
@@ -486,7 +464,7 @@ paths:
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
-                        maxSendAmount:
+                        debitAmount:
                           value: '7126'
                           assetCode: USD
                           assetScale: 2
@@ -498,15 +476,6 @@ paths:
                           value: '7026'
                           assetCode: USD
                           assetScale: 2
-                        fees:
-                          sendFeeAmount:
-                            value: '100'
-                            assetCode: USD
-                            assetScale: 2
-                          receiveFeeAmount:
-                            value: '0'
-                            assetCode: USD
-                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
@@ -524,7 +493,7 @@ paths:
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
-                        maxSendAmount:
+                        debitAmount:
                           value: '7126'
                           assetCode: USD
                           assetScale: 2
@@ -536,15 +505,6 @@ paths:
                           value: '7026'
                           assetCode: USD
                           assetScale: 2
-                        fees:
-                          sendFeeAmount:
-                            value: '100'
-                            assetCode: USD
-                            assetScale: 2
-                          receiveFeeAmount:
-                            value: '0'
-                            assetCode: USD
-                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
@@ -558,7 +518,7 @@ paths:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
-                        maxSendAmount:
+                        debitAmount:
                           value: '2600'
                           assetCode: USD
                           assetScale: 2
@@ -566,15 +526,6 @@ paths:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
-                        fees:
-                          sendFeeAmount:
-                            value: '100'
-                            assetCode: USD
-                            assetScale: 2
-                          receiveFeeAmount:
-                            value: '0'
-                            assetCode: USD
-                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
@@ -612,7 +563,7 @@ paths:
                     id: 'https://openpayments.guide/alice/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
                     paymentPointer: 'https://openpayments.guide/alice/'
                     receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
-                    maxSendAmount:
+                    debitAmount:
                       value: '2500'
                       assetCode: USD
                       assetScale: 2
@@ -620,15 +571,6 @@ paths:
                       value: '2198'
                       assetCode: EUR
                       assetScale: 2
-                    fees:
-                      sendFeeAmount:
-                        value: '100'
-                        assetCode: USD
-                        assetScale: 2
-                      receiveFeeAmount:
-                        value: '0'
-                        assetCode: USD
-                        assetScale: 2
                     createdAt: '2022-03-12T23:20:50.52Z'
                     expiresAt: '2022-04-12T23:20:50.52Z'
         '400':
@@ -816,7 +758,7 @@ paths:
                     paymentPointer: 'https://openpayments.guide/bob/'
                     failed: false
                     receiver: 'https://openpayments.guide/alice/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
-                    maxSendAmount:
+                    debitAmount:
                       value: '2500'
                       assetCode: USD
                       assetScale: 2
@@ -828,15 +770,6 @@ paths:
                       value: '1205'
                       assetCode: USD
                       assetScale: 2
-                    fees:
-                      sendFeeAmount:
-                        value: '100'
-                        assetCode: USD
-                        assetScale: 2
-                      receiveFeeAmount:
-                        value: '0'
-                        assetCode: USD
-                        assetScale: 2
                     createdAt: '2022-03-12T23:20:50.52Z'
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     metadata:
@@ -873,7 +806,7 @@ paths:
                     id: 'https://openpayments.guide/bob/quotes/3859b39e-4666-4ce5-8745-72f1864c5371'
                     paymentPointer: 'https://openpayments.guide/bob/'
                     receiver: 'https://openpayments.guide/alice/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
-                    maxSendAmount:
+                    debitAmount:
                       value: '2500'
                       assetCode: USD
                       assetScale: 2
@@ -881,15 +814,6 @@ paths:
                       value: '2198'
                       assetCode: EUR
                       assetScale: 2
-                    fees:
-                      sendFeeAmount:
-                        value: '100'
-                        assetCode: USD
-                        assetScale: 2
-                      receiveFeeAmount:
-                        value: '0'
-                        assetCode: USD
-                        assetScale: 2
                     createdAt: '2022-03-12T23:20:50.52Z'
                     expiresAt: '2022-04-12T23:20:50.52Z'
         '401':
@@ -1061,9 +985,6 @@ components:
         metadata:
           type: object
           description: Additional metadata associated with the incoming payment. (Optional)
-        feeStructure:
-          $ref: '#/components/schemas/feeStructure'
-          description: Fixed and variable receiving Account Servicing Entity fees.
         createdAt:
           type: string
           format: date-time
@@ -1154,7 +1075,7 @@ components:
             value: '2500'
             assetCode: USD
             assetScale: 2
-          maxSendAmount:
+          debitAmount:
             value: '2600'
             assetCode: USD
             assetScale: 2
@@ -1162,15 +1083,6 @@ components:
             value: '2500'
             assetCode: USD
             assetScale: 2
-          fees:
-            sendFeeAmount:
-              value: '100'
-              assetCode: USD
-              assetScale: 2
-            receiveFeeAmount:
-              value: '0'
-              assetCode: USD
-              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           updatedAt: '2022-04-01T10:24:36.11Z'
           metadata:
@@ -1180,7 +1092,7 @@ components:
           paymentPointer: 'https://openpayments.guide/alice/'
           failed: false
           receiver: 'https://openpayments.guide/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
-          maxSendAmount:
+          debitAmount:
             value: '7126'
             assetCode: USD
             assetScale: 2
@@ -1188,15 +1100,6 @@ components:
             value: '7026'
             assetCode: USD
             assetScale: 2
-          fees:
-            sendFeeAmount:
-              value: '100'
-              assetCode: USD
-              assetScale: 2
-            receiveFeeAmount:
-              value: '0'
-              assetCode: USD
-              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           updatedAt: '2022-04-01T10:24:36.11Z'
           metadata:
@@ -1229,7 +1132,7 @@ components:
         receiveAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
           description: The total amount that should be received by the receiver when this outgoing payment has been paid.
-        maxSendAmount:
+        debitAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
           description: The total amount that should be deducted from the sender's account when this outgoing payment has been paid.
         sentAmount:
@@ -1238,9 +1141,6 @@ components:
         metadata:
           type: object
           description: Additional metadata associated with the outgoing payment. (Optional)
-        fees:
-          $ref: '#/components/schemas/fees'
-          description: Fee structure
         createdAt:
           type: string
           format: date-time
@@ -1254,9 +1154,8 @@ components:
         - paymentPointer
         - receiver
         - receiveAmount
-        - maxSendAmount
+        - debitAmount
         - sentAmount
-        - fees
         - createdAt
         - updatedAt
     quote:
@@ -1271,7 +1170,7 @@ components:
             value: '2500'
             assetCode: USD
             assetScale: 2
-          maxSendAmount:
+          debitAmount:
             value: '2600'
             assetCode: USD
             assetScale: 2
@@ -1279,21 +1178,12 @@ components:
             value: '2500'
             assetCode: USD
             assetScale: 2
-          fees:
-            sendFeeAmount:
-              value: '100'
-              assetCode: USD
-              assetScale: 2
-            receiveFeeAmount:
-              value: '0'
-              assetCode: USD
-              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           expiresAt: '2022-04-12T23:20:50.52Z'
         - id: 'https://openpayments.guide/alice/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
           paymentPointer: 'https://openpayments.guide/alice/'
           receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
-          maxSendAmount:
+          debitAmount:
             value: '7126'
             assetCode: USD
             assetScale: 2
@@ -1301,15 +1191,6 @@ components:
             value: '7026'
             assetCode: USD
             assetScale: 2
-          fees:
-            sendFeeAmount:
-              value: '100'
-              assetCode: USD
-              assetScale: 2
-            receiveFeeAmount:
-              value: '0'
-              assetCode: USD
-              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           expiresAt: '2022-04-12T23:20:50.52Z'
       additionalProperties: false
@@ -1330,12 +1211,9 @@ components:
         receiveAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
           description: The total amount that should be received by the receiver when the corresponding outgoing payment has been paid.
-        maxSendAmount:
+        debitAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
           description: "The total amount that should be deducted from the sender's account when the corresponding outgoing payment has been paid. "
-        fees:
-          $ref: '#/components/schemas/fees'
-          description: Fee structure
         expiresAt:
           type: string
           description: The date and time when the calculated `sendAmount` is no longer valid.
@@ -1349,8 +1227,7 @@ components:
         - paymentPointer
         - receiver
         - receiveAmount
-        - maxSendAmount
-        - fees
+        - debitAmount
         - createdAt
     page-info:
       description: ''
@@ -1424,27 +1301,6 @@ components:
           kty: OKP
           crv: Ed25519
           x: oy0L_vTygNE4IogRyn_F5GmHXdqYVjIXkWs2jky7zsI
-    feeStructure:
-      title: feeStructure
-      type: object
-      properties:
-        fixed:
-          $ref: ./schemas.yaml#/components/schemas/amount
-        percentage:
-          type: string
-    fees:
-      title: fees
-      type: object
-      properties:
-        sendFeeAmount:
-          $ref: ./schemas.yaml#/components/schemas/amount
-          description: Sending Accoung Servicing Entity's fees + ILP network fees
-        receiveFeeAmount:
-          $ref: ./schemas.yaml#/components/schemas/amount
-          description: Receiving Account Servicing Entity's fees. They are zero if sender does not pay receiving fees.
-      required:
-        - sendFeeAmount
-        - receiveFeeAmount
   securitySchemes:
     GNAP:
       name: Authorization

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -403,7 +403,7 @@ paths:
         description: |-
           A subset of the outgoing payments schema is accepted as input to create a new outgoing payment.
 
-          The `sendAmount` must use the same `assetCode` and `assetScale` as the payment pointer.
+          The `debitAmount` must use the same `assetCode` and `assetScale` as the payment pointer.
         required: true
       description: |-
         An **outgoing payment** is a sub-resource of a payment pointer. It represents a payment from the payment pointer.
@@ -586,7 +586,7 @@ paths:
               Create fixed-send-amount quote for $25 to an ILP STREAM connection:
                 value:
                   receiver: 'https://openpayments.guide/connections/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
-                  sendAmount:
+                  debitAmount:
                     value: '2500'
                     assetCode: USD
                     assetScale: 2
@@ -621,17 +621,17 @@ paths:
                   properties:
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
-                    sendAmount:
+                    debitAmount:
                       description: The fixed amount that would be sent from the sending payment pointer given a successful outgoing payment.
                       $ref: ./schemas.yaml#/components/schemas/amount
                   required:
                     - receiver
-                    - sendAmount
+                    - debitAmount
                   additionalProperties: false
         description: |-
           A subset of the quotes schema is accepted as input to create a new quote.
 
-          The quote must be created with a (`sendAmount` xor `receiveAmount`) unless the `receiver` is an Incoming Payment which has an `incomingAmount`.
+          The quote must be created with a (`debitAmount` xor `receiveAmount`) unless the `receiver` is an Incoming Payment which has an `incomingAmount`.
         required: true
       description: A **quote** is a sub-resource of a payment pointer. It represents a quote for a payment from the payment pointer.
       parameters:
@@ -1216,7 +1216,7 @@ components:
           description: "The total amount that should be deducted from the sender's account when the corresponding outgoing payment has been paid. "
         expiresAt:
           type: string
-          description: The date and time when the calculated `sendAmount` is no longer valid.
+          description: The date and time when the calculated `debitAmount` is no longer valid.
           readOnly: true
         createdAt:
           type: string

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1332,7 +1332,7 @@ components:
           description: The total amount that should be received by the receiver when the corresponding outgoing payment has been paid.
         maxSendAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
-          description: 'The total amount that should be deducted from the sender''s account when the corresponding outgoing payment has been paid. '
+          description: "The total amount that should be deducted from the sender's account when the corresponding outgoing payment has been paid. "
         fees:
           $ref: '#/components/schemas/fees'
           description: Fee structure

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -36,12 +36,12 @@ servers:
     description: 'Server for when Payment Pointer has a pathname  (ie https://openpayments.guide/alice)'
     variables:
       paymentPointer:
-        default: openpayments.guide/alice
+        default: https://openpayments.guide/alice
   - url: '{paymentPointer}/.well-known/pay'
     description: 'Server for when Payment Pointer has no pathname (ie https://openpayments.guide)'
     variables:
       paymentPointer:
-        default: openpayments.guide
+        default: https://openpayments.guide
 tags:
   - name: payment-pointer
     description: payment pointer operations

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -167,7 +167,8 @@ paths:
                       assetScale: 2
                     completed: false
                     expiresAt: '2022-02-03T23:20:50.52Z'
-                    metadata: { externalRef: 'INV2022-02-0137' }
+                    metadata:
+                      externalRef: INV2022-02-0137
                     ilpStreamConnection:
                       id: 'https://openpayments.guide/connections/ff394f02-7b7b-45e2-b645-51d04e7c345c'
                       ilpAddress: g.ilp.iwuyge987y.98y08y
@@ -185,10 +186,11 @@ paths:
           application/json:
             schema:
               type: object
+              additionalProperties: false
               properties:
                 incomingAmount:
-                  description: The maximum amount that should be paid into the payment pointer under this incoming payment.
                   $ref: ./schemas.yaml#/components/schemas/amount
+                  description: The maximum amount that should be paid into the payment pointer under this incoming payment.
                 expiresAt:
                   type: string
                   description: The date and time when payments into the incoming payment must no longer be accepted.
@@ -196,9 +198,10 @@ paths:
                   writeOnly: true
                 metadata:
                   type: object
-                  additionalProperties: true
                   description: Additional metadata associated with the incoming payment. (Optional)
-              additionalProperties: false
+                feeStructure:
+                  type: boolean
+                  description: Request receiving fee structure
             examples:
               Create incoming payment for $25 to pay invoice INV2022-02-0137:
                 value:
@@ -206,7 +209,9 @@ paths:
                     value: '2500'
                     assetCode: USD
                     assetScale: 2
-                  metadata: { externalRef: 'INV2022-02-0137' }
+                  metadata:
+                    externalRef: INV2022-02-0137
+                  feeStructure: true
         description: |-
           A subset of the incoming payments schema is accepted as input to create a new incoming payment.
 
@@ -268,10 +273,8 @@ paths:
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
-                            externalRef: 'Coffee w/ Mo on 10 March 22'
-                          }
+                          description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
+                          externalRef: Coffee w/ Mo on 10 March 22
                         completed: true
                       - id: 'https://openpayments.guide/alice/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
                         paymentPointer: 'https://openpayments.guide/alice/'
@@ -284,9 +287,7 @@ paths:
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'I love your website, Alice! Thanks for the great content'
-                          }
+                          description: 'I love your website, Alice! Thanks for the great content'
                         completed: false
                 backward pagination:
                   value:
@@ -308,9 +309,7 @@ paths:
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'I love your website, Alice! Thanks for the great content'
-                          }
+                          description: 'I love your website, Alice! Thanks for the great content'
                       - id: 'https://openpayments.guide/alice/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
                         paymentPointer: 'https://openpayments.guide/alice/'
                         incomingAmount:
@@ -327,10 +326,8 @@ paths:
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
-                            externalRef: 'Coffee w/ Mo on 10 March 22'
-                          }
+                          description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
+                          externalRef: Coffee w/ Mo on 10 March 22
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -364,8 +361,8 @@ paths:
                     paymentPointer: 'https://openpayments.guide/alice/'
                     failed: false
                     receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
-                    sendAmount:
-                      value: '2500'
+                    maxSendAmount:
+                      value: '2600'
                       assetCode: USD
                       assetScale: 2
                     receiveAmount:
@@ -376,7 +373,17 @@ paths:
                       value: '0'
                       assetCode: USD
                       assetScale: 2
-                    metadata: { description: Thank you for the shoes. }
+                    fees:
+                      sendFeeAmount:
+                        value: '100'
+                        assetCode: USD
+                        assetScale: 2
+                      receiveFeeAmount:
+                        value: '0'
+                        assetCode: USD
+                        assetScale: 2
+                    metadata:
+                      description: Thank you for the shoes.
                     createdAt: '2022-03-12T23:20:50.52Z'
                     updatedAt: '2022-04-01T10:24:36.11Z'
         '401':
@@ -390,7 +397,8 @@ paths:
               Create an outgoing payment based on a quote:
                 value:
                   quoteId: 'https://openpayments.guide/alice/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
-                  metadata: { externalRef: 'INV2022-02-0137' }
+                  metadata:
+                    externalRef: INV2022-02-0137
             schema:
               type: object
               properties:
@@ -452,27 +460,34 @@ paths:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
-                        sendAmount:
-                          value: '2500'
+                        maxSendAmount:
+                          value: '2600'
                           assetCode: USD
                           assetScale: 2
                         sentAmount:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
+                        fees:
+                          sendFeeAmount:
+                            value: '100'
+                            assetCode: USD
+                            assetScale: 2
+                          receiveFeeAmount:
+                            value: '0'
+                            assetCode: USD
+                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'APlusVideo subscription',
-                            externalRef: 'customer: 847458475'
-                          }
+                          description: APlusVideo subscription
+                          externalRef: 'customer: 847458475'
                       - id: 'https://openpayments.guide/alice/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
-                        sendAmount:
-                          value: '7026'
+                        maxSendAmount:
+                          value: '7126'
                           assetCode: USD
                           assetScale: 2
                         receiveAmount:
@@ -483,13 +498,20 @@ paths:
                           value: '7026'
                           assetCode: USD
                           assetScale: 2
+                        fees:
+                          sendFeeAmount:
+                            value: '100'
+                            assetCode: USD
+                            assetScale: 2
+                          receiveFeeAmount:
+                            value: '0'
+                            assetCode: USD
+                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'Thank you for your purchase at ShoeShop!',
-                            externalRef: 'INV2022-8943756'
-                          }
+                          description: Thank you for your purchase at ShoeShop!
+                          externalRef: INV2022-8943756
                 backward pagination:
                   value:
                     pagination:
@@ -502,8 +524,8 @@ paths:
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
-                        sendAmount:
-                          value: '7026'
+                        maxSendAmount:
+                          value: '7126'
                           assetCode: USD
                           assetScale: 2
                         receiveAmount:
@@ -514,13 +536,20 @@ paths:
                           value: '7026'
                           assetCode: USD
                           assetScale: 2
+                        fees:
+                          sendFeeAmount:
+                            value: '100'
+                            assetCode: USD
+                            assetScale: 2
+                          receiveFeeAmount:
+                            value: '0'
+                            assetCode: USD
+                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'Thank you for your purchase at ShoeShop!',
-                            externalRef: 'INV2022-8943756'
-                          }
+                          description: Thank you for your purchase at ShoeShop!
+                          externalRef: INV2022-8943756
                       - id: 'https://openpayments.guide/alice/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
                         paymentPointer: 'https://openpayments.guide/alice/'
                         failed: false
@@ -529,21 +558,28 @@ paths:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
-                        sendAmount:
-                          value: '2500'
+                        maxSendAmount:
+                          value: '2600'
                           assetCode: USD
                           assetScale: 2
                         sentAmount:
                           value: '2500'
                           assetCode: USD
                           assetScale: 2
+                        fees:
+                          sendFeeAmount:
+                            value: '100'
+                            assetCode: USD
+                            assetScale: 2
+                          receiveFeeAmount:
+                            value: '0'
+                            assetCode: USD
+                            assetScale: 2
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
-                          {
-                            description: 'APlusVideo subscription',
-                            externalRef: 'customer: 847458475'
-                          }
+                          description: APlusVideo subscription
+                          externalRef: 'customer: 847458475'
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -576,7 +612,7 @@ paths:
                     id: 'https://openpayments.guide/alice/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
                     paymentPointer: 'https://openpayments.guide/alice/'
                     receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
-                    sendAmount:
+                    maxSendAmount:
                       value: '2500'
                       assetCode: USD
                       assetScale: 2
@@ -584,6 +620,15 @@ paths:
                       value: '2198'
                       assetCode: EUR
                       assetScale: 2
+                    fees:
+                      sendFeeAmount:
+                        value: '100'
+                        assetCode: USD
+                        assetScale: 2
+                      receiveFeeAmount:
+                        value: '0'
+                        assetCode: USD
+                        assetScale: 2
                     createdAt: '2022-03-12T23:20:50.52Z'
                     expiresAt: '2022-04-12T23:20:50.52Z'
         '400':
@@ -641,7 +686,6 @@ paths:
                     - receiver
                     - sendAmount
                   additionalProperties: false
-
         description: |-
           A subset of the quotes schema is accepted as input to create a new quote.
 
@@ -683,10 +727,8 @@ paths:
                     createdAt: '2022-03-12T23:20:50.52Z'
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     metadata:
-                      {
-                        description: 'Thanks for the flowers!',
-                        externalRef: 'INV-12876'
-                      }
+                      description: Thanks for the flowers!
+                      externalRef: INV-12876
                     ilpStreamConnection:
                       id: 'https://openpayments.guide/connections/4a1b0150-db73-49e8-8713-628baa4a17ff'
                       ilpAddress: g.ilp.iwuyge987y.98y08y
@@ -737,10 +779,8 @@ paths:
                     createdAt: '2022-03-12T23:20:50.52Z'
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     metadata:
-                      {
-                        description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
-                        externalRef: 'Coffee w/ Mo on 10 March 2'
-                      }
+                      description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
+                      externalRef: Coffee w/ Mo on 10 March 2
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -776,7 +816,7 @@ paths:
                     paymentPointer: 'https://openpayments.guide/bob/'
                     failed: false
                     receiver: 'https://openpayments.guide/alice/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
-                    sendAmount:
+                    maxSendAmount:
                       value: '2500'
                       assetCode: USD
                       assetScale: 2
@@ -788,13 +828,20 @@ paths:
                       value: '1205'
                       assetCode: USD
                       assetScale: 2
+                    fees:
+                      sendFeeAmount:
+                        value: '100'
+                        assetCode: USD
+                        assetScale: 2
+                      receiveFeeAmount:
+                        value: '0'
+                        assetCode: USD
+                        assetScale: 2
                     createdAt: '2022-03-12T23:20:50.52Z'
                     updatedAt: '2022-04-01T10:24:36.11Z'
                     metadata:
-                      {
-                        description: 'Thanks for the flowers!',
-                        externalRef: 'INV-12876'
-                      }
+                      description: Thanks for the flowers!
+                      externalRef: INV-12876
         '401':
           $ref: '#/components/responses/401'
         '403':
@@ -826,7 +873,7 @@ paths:
                     id: 'https://openpayments.guide/bob/quotes/3859b39e-4666-4ce5-8745-72f1864c5371'
                     paymentPointer: 'https://openpayments.guide/bob/'
                     receiver: 'https://openpayments.guide/alice/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
-                    sendAmount:
+                    maxSendAmount:
                       value: '2500'
                       assetCode: USD
                       assetScale: 2
@@ -834,6 +881,15 @@ paths:
                       value: '2198'
                       assetCode: EUR
                       assetScale: 2
+                    fees:
+                      sendFeeAmount:
+                        value: '100'
+                        assetCode: USD
+                        assetScale: 2
+                      receiveFeeAmount:
+                        value: '0'
+                        assetCode: USD
+                        assetScale: 2
                     createdAt: '2022-03-12T23:20:50.52Z'
                     expiresAt: '2022-04-12T23:20:50.52Z'
         '401':
@@ -962,10 +1018,8 @@ components:
           createdAt: '2022-03-12T23:20:50.52Z'
           updatedAt: '2022-04-01T10:24:36.11Z'
           metadata:
-            {
-              description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
-              externalRef: 'Coffee w/ Mo on 10 March 22'
-            }
+            description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
+            externalRef: Coffee w/ Mo on 10 March 22
         - id: 'https://openpayments.guide/alice/incoming-payments/456da9d5-c9a4-4c80-a354-86b915a04ff8'
           paymentPointer: 'https://openpayments.guide/alice/'
           incomingAmount:
@@ -995,19 +1049,21 @@ components:
           description: Describes whether the incoming payment has completed receiving fund.
           default: false
         incomingAmount:
+          $ref: ./schemas.yaml#/components/schemas/amount
           description: The maximum amount that should be paid into the payment pointer under this incoming payment.
-          $ref: ./schemas.yaml#/components/schemas/amount
         receivedAmount:
-          description: The total amount that has been paid into the payment pointer under this incoming payment.
           $ref: ./schemas.yaml#/components/schemas/amount
+          description: The total amount that has been paid into the payment pointer under this incoming payment.
         expiresAt:
           type: string
           description: The date and time when payments under this incoming payment will no longer be accepted.
           format: date-time
         metadata:
           type: object
-          additionalProperties: true
           description: Additional metadata associated with the incoming payment. (Optional)
+        feeStructure:
+          $ref: '#/components/schemas/feeStructure'
+          description: Fixed and variable receiving Account Servicing Entity fees.
         createdAt:
           type: string
           format: date-time
@@ -1043,10 +1099,8 @@ components:
           createdAt: '2022-03-12T23:20:50.52Z'
           updatedAt: '2022-04-01T10:24:36.11Z'
           metadata:
-            {
-              description: 'Hi Mo, this is for the cappuccino I bought for you the other day.',
-              externalRef: 'Coffee w/ Mo on 10 March 22'
-            }
+            description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
+            externalRef: Coffee w/ Mo on 10 March 22
           ilpStreamConnection:
             id: 'https://openpayments.guide/connections/032da9d5-c9a4-4c80-a354-86b915a04ff8'
             ilpApddress: g.ilp.iwuyge987y.98y08y
@@ -1100,40 +1154,55 @@ components:
             value: '2500'
             assetCode: USD
             assetScale: 2
-          sendAmount:
-            value: '2500'
+          maxSendAmount:
+            value: '2600'
             assetCode: USD
             assetScale: 2
           sentAmount:
             value: '2500'
             assetCode: USD
             assetScale: 2
+          fees:
+            sendFeeAmount:
+              value: '100'
+              assetCode: USD
+              assetScale: 2
+            receiveFeeAmount:
+              value: '0'
+              assetCode: USD
+              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           updatedAt: '2022-04-01T10:24:36.11Z'
           metadata:
-            {
-              description: 'APlusVideo subscription',
-              externalRef: 'customer: 847458475'
-            }
+            description: APlusVideo subscription
+            externalRef: 'customer: 847458475'
         - id: 'https://openpayments.guide/alice/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
           paymentPointer: 'https://openpayments.guide/alice/'
           failed: false
           receiver: 'https://openpayments.guide/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
-          sendAmount:
-            value: '7026'
+          maxSendAmount:
+            value: '7126'
             assetCode: USD
             assetScale: 2
           sentAmount:
             value: '7026'
             assetCode: USD
             assetScale: 2
+          fees:
+            sendFeeAmount:
+              value: '100'
+              assetCode: USD
+              assetScale: 2
+            receiveFeeAmount:
+              value: '0'
+              assetCode: USD
+              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           updatedAt: '2022-04-01T10:24:36.11Z'
           metadata:
-            {
-              description: 'Thank you for your purchase at ShoeShop!',
-              externalRef: 'INV2022-8943756'
-            }
+            description: Thank you for your purchase at ShoeShop!
+            externalRef: INV2022-8943756
+      additionalProperties: false
       properties:
         id:
           type: string
@@ -1155,21 +1224,23 @@ components:
           description: Describes whether the payment failed to send its full amount.
           default: false
         receiver:
-          description: The URL of the incoming payment or ILP STREAM Connection that is being paid.
           $ref: ./schemas.yaml#/components/schemas/receiver
+          description: The URL of the incoming payment or ILP STREAM Connection that is being paid.
         receiveAmount:
+          $ref: ./schemas.yaml#/components/schemas/amount
           description: The total amount that should be received by the receiver when this outgoing payment has been paid.
+        maxSendAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
-        sendAmount:
-          description: The total amount that should be sent when this outgoing payment has been paid.
-          $ref: ./schemas.yaml#/components/schemas/amount
+          description: The total amount that should be deducted from the sender's account when this outgoing payment has been paid.
         sentAmount:
-          description: The total amount that has been sent under this outgoing payment.
           $ref: ./schemas.yaml#/components/schemas/amount
+          description: The total amount that has been sent under this outgoing payment.
         metadata:
           type: object
-          additionalProperties: true
           description: Additional metadata associated with the outgoing payment. (Optional)
+        fees:
+          $ref: '#/components/schemas/fees'
+          description: Fee structure
         createdAt:
           type: string
           format: date-time
@@ -1182,12 +1253,12 @@ components:
         - id
         - paymentPointer
         - receiver
-        - sendAmount
         - receiveAmount
+        - maxSendAmount
         - sentAmount
+        - fees
         - createdAt
         - updatedAt
-      additionalProperties: false
     quote:
       title: Quote
       description: A **quote** resource represents the quoted amount details with which an Outgoing Payment may be created.
@@ -1200,23 +1271,45 @@ components:
             value: '2500'
             assetCode: USD
             assetScale: 2
-          sendAmount:
+          maxSendAmount:
+            value: '2600'
+            assetCode: USD
+            assetScale: 2
+          sentAmount:
             value: '2500'
             assetCode: USD
             assetScale: 2
+          fees:
+            sendFeeAmount:
+              value: '100'
+              assetCode: USD
+              assetScale: 2
+            receiveFeeAmount:
+              value: '0'
+              assetCode: USD
+              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           expiresAt: '2022-04-12T23:20:50.52Z'
         - id: 'https://openpayments.guide/alice/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
           paymentPointer: 'https://openpayments.guide/alice/'
           receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
-          sendAmount:
-            value: '2500'
+          maxSendAmount:
+            value: '7126'
             assetCode: USD
             assetScale: 2
-          receiveAmount:
-            value: '2198'
-            assetCode: EUR
+          sentAmount:
+            value: '7026'
+            assetCode: USD
             assetScale: 2
+          fees:
+            sendFeeAmount:
+              value: '100'
+              assetCode: USD
+              assetScale: 2
+            receiveFeeAmount:
+              value: '0'
+              assetCode: USD
+              assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           expiresAt: '2022-04-12T23:20:50.52Z'
       additionalProperties: false
@@ -1233,10 +1326,16 @@ components:
           readOnly: true
         receiver:
           $ref: ./schemas.yaml#/components/schemas/receiver
+          description: The URL of the incoming payment or ILP STREAM Connection that the quote is created for.
         receiveAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
-        sendAmount:
+          description: The total amount that should be received by the receiver when the corresponding outgoing payment has been paid.
+        maxSendAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
+          description: 'The total amount that should be deducted from the sender''s account when the corresponding outgoing payment has been paid. '
+        fees:
+          $ref: '#/components/schemas/fees'
+          description: Fee structure
         expiresAt:
           type: string
           description: The date and time when the calculated `sendAmount` is no longer valid.
@@ -1250,7 +1349,8 @@ components:
         - paymentPointer
         - receiver
         - receiveAmount
-        - sendAmount
+        - maxSendAmount
+        - fees
         - createdAt
     page-info:
       description: ''
@@ -1324,6 +1424,27 @@ components:
           kty: OKP
           crv: Ed25519
           x: oy0L_vTygNE4IogRyn_F5GmHXdqYVjIXkWs2jky7zsI
+    feeStructure:
+      title: feeStructure
+      type: object
+      properties:
+        fixed:
+          $ref: ./schemas.yaml#/components/schemas/amount
+        percentage:
+          type: string
+    fees:
+      title: fees
+      type: object
+      properties:
+        sendFeeAmount:
+          $ref: ./schemas.yaml#/components/schemas/amount
+          description: Sending Accoung Servicing Entity's fees + ILP network fees
+        receiveFeeAmount:
+          $ref: ./schemas.yaml#/components/schemas/amount
+          description: Receiving Account Servicing Entity's fees. They are zero if sender does not pay receiving fees.
+      required:
+        - sendFeeAmount
+        - receiveFeeAmount
   securitySchemes:
     GNAP:
       name: Authorization

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Open Payments
-  version: '1.1'
+  version: '1.2'
   license:
     name: Apache 2.0
     identifier: Apache-2.0

--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -14,7 +14,6 @@ components:
     amount:
       title: amount
       type: object
-      description: 'All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.'
       properties:
         value:
           type: string

--- a/packages/open-payments/README.md
+++ b/packages/open-payments/README.md
@@ -179,7 +179,7 @@ const quote = await client.quote.create(
   { receiver: incomingPayment.id }
 )
 
-// quote.sendAmount.value = '5200'
+// quote.debitAmount.value = '5200'
 ```
 
 5. Create `OutgoingPayment` grant & start interaction flow:

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -62,7 +62,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if outgoing payment does not pass validation', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        sendAmount: {
+        maxSendAmount: {
           assetCode: 'USD',
           assetScale: 3,
           value: '5'
@@ -194,7 +194,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if an outgoing payment does not pass validation', async (): Promise<void> => {
       const invalidOutgoingPayment = mockOutgoingPayment({
-        sendAmount: {
+        maxSendAmount: {
           assetCode: 'CAD',
           assetScale: 2,
           value: '5'
@@ -291,7 +291,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if outgoing payment does not pass validation', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        sendAmount: {
+        maxSendAmount: {
           assetCode: 'USD',
           assetScale: 3,
           value: '5'
@@ -361,7 +361,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if send amount and sent amount asset scales are different', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        sendAmount: {
+        maxSendAmount: {
           assetCode: 'USD',
           assetScale: 3,
           value: '5'
@@ -380,7 +380,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if send amount and sent amount asset codes are different', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        sendAmount: {
+        maxSendAmount: {
           assetCode: 'CAD',
           assetScale: 2,
           value: '5'
@@ -399,7 +399,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if sent amount is larger than send amount', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        sendAmount: {
+        maxSendAmount: {
           assetCode: 'USD',
           assetScale: 2,
           value: '5'
@@ -418,7 +418,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if sent amount equals send amount, but payment has failed', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        sendAmount: {
+        maxSendAmount: {
           assetCode: 'USD',
           assetScale: 2,
           value: '5'

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -62,7 +62,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if outgoing payment does not pass validation', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        maxSendAmount: {
+        debitAmount: {
           assetCode: 'USD',
           assetScale: 3,
           value: '5'
@@ -194,7 +194,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if an outgoing payment does not pass validation', async (): Promise<void> => {
       const invalidOutgoingPayment = mockOutgoingPayment({
-        maxSendAmount: {
+        debitAmount: {
           assetCode: 'CAD',
           assetScale: 2,
           value: '5'
@@ -291,7 +291,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if outgoing payment does not pass validation', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        maxSendAmount: {
+        debitAmount: {
           assetCode: 'USD',
           assetScale: 3,
           value: '5'
@@ -361,7 +361,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if send amount and sent amount asset scales are different', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        maxSendAmount: {
+        debitAmount: {
           assetCode: 'USD',
           assetScale: 3,
           value: '5'
@@ -380,7 +380,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if send amount and sent amount asset codes are different', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        maxSendAmount: {
+        debitAmount: {
           assetCode: 'CAD',
           assetScale: 2,
           value: '5'
@@ -399,7 +399,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if sent amount is larger than send amount', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        maxSendAmount: {
+        debitAmount: {
           assetCode: 'USD',
           assetScale: 2,
           value: '5'
@@ -418,7 +418,7 @@ describe('outgoing-payment', (): void => {
 
     test('throws if sent amount equals send amount, but payment has failed', async (): Promise<void> => {
       const outgoingPayment = mockOutgoingPayment({
-        maxSendAmount: {
+        debitAmount: {
           assetCode: 'USD',
           assetScale: 2,
           value: '5'

--- a/packages/open-payments/src/client/outgoing-payment.ts
+++ b/packages/open-payments/src/client/outgoing-payment.ts
@@ -176,19 +176,19 @@ export const listOutgoingPayments = async (
 export const validateOutgoingPayment = (
   payment: OutgoingPayment
 ): OutgoingPayment => {
-  const { maxSendAmount, sentAmount } = payment
+  const { debitAmount, sentAmount } = payment
   if (
-    maxSendAmount.assetCode !== sentAmount.assetCode ||
-    maxSendAmount.assetScale !== sentAmount.assetScale
+    debitAmount.assetCode !== sentAmount.assetCode ||
+    debitAmount.assetScale !== sentAmount.assetScale
   ) {
     throw new Error(
       'Asset code or asset scale of sending amount does not match sent amount'
     )
   }
-  if (BigInt(maxSendAmount.value) < BigInt(sentAmount.value)) {
+  if (BigInt(debitAmount.value) < BigInt(sentAmount.value)) {
     throw new Error('Amount sent is larger than maximum amount to send')
   }
-  if (maxSendAmount.value === sentAmount.value && payment.failed) {
+  if (debitAmount.value === sentAmount.value && payment.failed) {
     throw new Error('Amount to send matches sent amount but payment failed')
   }
 

--- a/packages/open-payments/src/client/outgoing-payment.ts
+++ b/packages/open-payments/src/client/outgoing-payment.ts
@@ -176,19 +176,19 @@ export const listOutgoingPayments = async (
 export const validateOutgoingPayment = (
   payment: OutgoingPayment
 ): OutgoingPayment => {
-  const { sendAmount, sentAmount } = payment
+  const { maxSendAmount, sentAmount } = payment
   if (
-    sendAmount.assetCode !== sentAmount.assetCode ||
-    sendAmount.assetScale !== sentAmount.assetScale
+    maxSendAmount.assetCode !== sentAmount.assetCode ||
+    maxSendAmount.assetScale !== sentAmount.assetScale
   ) {
     throw new Error(
       'Asset code or asset scale of sending amount does not match sent amount'
     )
   }
-  if (BigInt(sendAmount.value) < BigInt(sentAmount.value)) {
+  if (BigInt(maxSendAmount.value) < BigInt(sentAmount.value)) {
     throw new Error('Amount sent is larger than maximum amount to send')
   }
-  if (sendAmount.value === sentAmount.value && payment.failed) {
+  if (maxSendAmount.value === sentAmount.value && payment.failed) {
     throw new Error('Amount to send matches sent amount but payment failed')
   }
 

--- a/packages/open-payments/src/openapi/generated/auth-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/auth-server-types.ts
@@ -166,7 +166,9 @@ export interface components {
      */
     "limits-outgoing": Partial<unknown> & {
       receiver?: external["schemas.yaml"]["components"]["schemas"]["receiver"];
+      /** @description All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant. */
       debitAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant. */
       receiveAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
       interval?: components["schemas"]["interval"];
     };
@@ -312,10 +314,7 @@ export interface external {
     paths: {};
     components: {
       schemas: {
-        /**
-         * amount
-         * @description All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-         */
+        /** amount */
         amount: {
           /**
            * Format: uint64

--- a/packages/open-payments/src/openapi/generated/auth-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/auth-server-types.ts
@@ -166,7 +166,7 @@ export interface components {
      */
     "limits-outgoing": Partial<unknown> & {
       receiver?: external["schemas.yaml"]["components"]["schemas"]["receiver"];
-      sendAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      debitAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
       receiveAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
       interval?: components["schemas"]["interval"];
     };

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -190,6 +190,8 @@ export interface components {
       expiresAt?: string;
       /** @description Additional metadata associated with the incoming payment. (Optional) */
       metadata?: { [key: string]: unknown };
+      /** @description Fixed and variable receiving Account Servicing Entity fees. */
+      feeStructure?: components["schemas"]["feeStructure"];
       /**
        * Format: date-time
        * @description The date and time when the incoming payment was created.
@@ -245,12 +247,14 @@ export interface components {
       receiver: external["schemas.yaml"]["components"]["schemas"]["receiver"];
       /** @description The total amount that should be received by the receiver when this outgoing payment has been paid. */
       receiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description The total amount that should be sent when this outgoing payment has been paid. */
-      sendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description The total amount that should be deducted from the sender's account when this outgoing payment has been paid. */
+      maxSendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that has been sent under this outgoing payment. */
       sentAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description Additional metadata associated with the outgoing payment. (Optional) */
       metadata?: { [key: string]: unknown };
+      /** @description Fee structure */
+      fees: components["schemas"]["fees"];
       /**
        * Format: date-time
        * @description The date and time when the outgoing payment was created.
@@ -277,9 +281,14 @@ export interface components {
        * @description The URL of the payment pointer from which this quote's payment would be sent.
        */
       paymentPointer: string;
+      /** @description The URL of the incoming payment or ILP STREAM Connection that the quote is created for. */
       receiver: external["schemas.yaml"]["components"]["schemas"]["receiver"];
+      /** @description The total amount that should be received by the receiver when the corresponding outgoing payment has been paid. */
       receiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      sendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description The total amount that should be deducted from the sender's account when the corresponding outgoing payment has been paid. */
+      maxSendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description Fee structure */
+      fees: components["schemas"]["fees"];
       /** @description The date and time when the calculated `sendAmount` is no longer valid. */
       expiresAt?: string;
       /**
@@ -311,6 +320,18 @@ export interface components {
       crv: "Ed25519";
       /** @description The base64 url-encoded public key. */
       x: string;
+    };
+    /** feeStructure */
+    feeStructure: {
+      fixed?: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      percentage?: string;
+    };
+    /** fees */
+    fees: {
+      /** @description Sending Accoung Servicing Entity's fees + ILP network fees */
+      sendFeeAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description Receiving Account Servicing Entity's fees. They are zero if sender does not pay receiving fees. */
+      receiveFeeAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
     };
   };
   responses: {
@@ -476,6 +497,8 @@ export interface operations {
           expiresAt?: string;
           /** @description Additional metadata associated with the incoming payment. (Optional) */
           metadata?: { [key: string]: unknown };
+          /** @description Request receiving fee structure */
+          feeStructure?: boolean;
         };
       };
     };

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -190,8 +190,6 @@ export interface components {
       expiresAt?: string;
       /** @description Additional metadata associated with the incoming payment. (Optional) */
       metadata?: { [key: string]: unknown };
-      /** @description Fixed and variable receiving Account Servicing Entity fees. */
-      feeStructure?: components["schemas"]["feeStructure"];
       /**
        * Format: date-time
        * @description The date and time when the incoming payment was created.
@@ -248,13 +246,11 @@ export interface components {
       /** @description The total amount that should be received by the receiver when this outgoing payment has been paid. */
       receiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that should be deducted from the sender's account when this outgoing payment has been paid. */
-      maxSendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that has been sent under this outgoing payment. */
       sentAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description Additional metadata associated with the outgoing payment. (Optional) */
       metadata?: { [key: string]: unknown };
-      /** @description Fee structure */
-      fees: components["schemas"]["fees"];
       /**
        * Format: date-time
        * @description The date and time when the outgoing payment was created.
@@ -286,9 +282,7 @@ export interface components {
       /** @description The total amount that should be received by the receiver when the corresponding outgoing payment has been paid. */
       receiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that should be deducted from the sender's account when the corresponding outgoing payment has been paid. */
-      maxSendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description Fee structure */
-      fees: components["schemas"]["fees"];
+      debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The date and time when the calculated `sendAmount` is no longer valid. */
       expiresAt?: string;
       /**
@@ -320,18 +314,6 @@ export interface components {
       crv: "Ed25519";
       /** @description The base64 url-encoded public key. */
       x: string;
-    };
-    /** feeStructure */
-    feeStructure: {
-      fixed?: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      percentage?: string;
-    };
-    /** fees */
-    fees: {
-      /** @description Sending Accoung Servicing Entity's fees + ILP network fees */
-      sendFeeAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description Receiving Account Servicing Entity's fees. They are zero if sender does not pay receiving fees. */
-      receiveFeeAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
     };
   };
   responses: {
@@ -497,8 +479,6 @@ export interface operations {
           expiresAt?: string;
           /** @description Additional metadata associated with the incoming payment. (Optional) */
           metadata?: { [key: string]: unknown };
-          /** @description Request receiving fee structure */
-          feeStructure?: boolean;
         };
       };
     };

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -723,10 +723,7 @@ export interface external {
     paths: {};
     components: {
       schemas: {
-        /**
-         * amount
-         * @description All amounts are maxima, i.e. multiple payments can be created under a grant as long as the total amounts of these payments do not exceed the maximum amount per interval as specified in the grant.
-         */
+        /** amount */
         amount: {
           /**
            * Format: uint64

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -283,7 +283,7 @@ export interface components {
       receiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that should be deducted from the sender's account when the corresponding outgoing payment has been paid. */
       debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description The date and time when the calculated `sendAmount` is no longer valid. */
+      /** @description The date and time when the calculated `debitAmount` is no longer valid. */
       expiresAt?: string;
       /**
        * Format: date-time
@@ -542,7 +542,7 @@ export interface operations {
     /**
      * A subset of the outgoing payments schema is accepted as input to create a new outgoing payment.
      *
-     * The `sendAmount` must use the same `assetCode` and `assetScale` as the payment pointer.
+     * The `debitAmount` must use the same `assetCode` and `assetScale` as the payment pointer.
      */
     requestBody: {
       content: {
@@ -583,7 +583,7 @@ export interface operations {
     /**
      * A subset of the quotes schema is accepted as input to create a new quote.
      *
-     * The quote must be created with a (`sendAmount` xor `receiveAmount`) unless the `receiver` is an Incoming Payment which has an `incomingAmount`.
+     * The quote must be created with a (`debitAmount` xor `receiveAmount`) unless the `receiver` is an Incoming Payment which has an `incomingAmount`.
      */
     requestBody: {
       content: {
@@ -599,7 +599,7 @@ export interface operations {
           | {
               receiver: external["schemas.yaml"]["components"]["schemas"]["receiver"];
               /** @description The fixed amount that would be sent from the sending payment pointer given a successful outgoing payment. */
-              sendAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+              debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
             };
       };
     };

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -154,7 +154,7 @@ export const mockOutgoingPayment = (
   id: `https://example.com/.well-known/pay/outgoing-payments/${uuid()}`,
   paymentPointer: 'https://example.com/.well-known/pay',
   failed: false,
-  sendAmount: {
+  maxSendAmount: {
     assetCode: 'USD',
     assetScale: 2,
     value: '10'
@@ -168,6 +168,18 @@ export const mockOutgoingPayment = (
     assetCode: 'USD',
     assetScale: 2,
     value: '10'
+  },
+  fees: {
+    sendFeeAmount: {
+      assetCode: 'USD',
+      assetScale: 2,
+      value: '0'
+    },
+    receiveFeeAmount: {
+      assetCode: 'USD',
+      assetScale: 2,
+      value: '0'
+    }
   },
   quoteId: uuid(),
   receiver: uuid(),
@@ -286,7 +298,7 @@ export const mockQuote = (overrides?: Partial<Quote>): Quote => ({
   id: `https://example.com/.well-known/pay/quotes/${uuid()}`,
   receiver: 'https://example.com/.well-known/peer',
   paymentPointer: 'https://example.com/.well-known/pay',
-  sendAmount: {
+  maxSendAmount: {
     value: '100',
     assetCode: 'USD',
     assetScale: 2
@@ -295,6 +307,18 @@ export const mockQuote = (overrides?: Partial<Quote>): Quote => ({
     value: '90',
     assetCode: 'USD',
     assetScale: 2
+  },
+  fees: {
+    sendFeeAmount: {
+      assetCode: 'USD',
+      assetScale: 2,
+      value: '0'
+    },
+    receiveFeeAmount: {
+      assetCode: 'USD',
+      assetScale: 2,
+      value: '0'
+    }
   },
   createdAt: new Date().toISOString(),
   expiresAt: new Date(Date.now() + 60_000).toISOString(),

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -154,7 +154,7 @@ export const mockOutgoingPayment = (
   id: `https://example.com/.well-known/pay/outgoing-payments/${uuid()}`,
   paymentPointer: 'https://example.com/.well-known/pay',
   failed: false,
-  maxSendAmount: {
+  debitAmount: {
     assetCode: 'USD',
     assetScale: 2,
     value: '10'
@@ -168,18 +168,6 @@ export const mockOutgoingPayment = (
     assetCode: 'USD',
     assetScale: 2,
     value: '10'
-  },
-  fees: {
-    sendFeeAmount: {
-      assetCode: 'USD',
-      assetScale: 2,
-      value: '0'
-    },
-    receiveFeeAmount: {
-      assetCode: 'USD',
-      assetScale: 2,
-      value: '0'
-    }
   },
   quoteId: uuid(),
   receiver: uuid(),
@@ -298,7 +286,7 @@ export const mockQuote = (overrides?: Partial<Quote>): Quote => ({
   id: `https://example.com/.well-known/pay/quotes/${uuid()}`,
   receiver: 'https://example.com/.well-known/peer',
   paymentPointer: 'https://example.com/.well-known/pay',
-  maxSendAmount: {
+  debitAmount: {
     value: '100',
     assetCode: 'USD',
     assetScale: 2
@@ -307,18 +295,6 @@ export const mockQuote = (overrides?: Partial<Quote>): Quote => ({
     value: '90',
     assetCode: 'USD',
     assetScale: 2
-  },
-  fees: {
-    sendFeeAmount: {
-      assetCode: 'USD',
-      assetScale: 2,
-      value: '0'
-    },
-    receiveFeeAmount: {
-      assetCode: 'USD',
-      assetScale: 2,
-      value: '0'
-    }
   },
   createdAt: new Date().toISOString(),
   expiresAt: new Date(Date.now() + 60_000).toISOString(),

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -52,7 +52,7 @@ type QuoteArgsBase = {
   receiver: RSOperations['create-quote']['requestBody']['content']['application/json']['receiver']
 }
 type QuoteArgsWithSendAmount = QuoteArgsBase & {
-  sendAmount?: RSComponents['schemas']['quote']['sendAmount']
+  sendAmount?: RSComponents['schemas']['quote']['maxSendAmount']
   receiveAmount?: never
 }
 type QuoteArgsWithReceiveAmount = QuoteArgsBase & {

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -51,16 +51,16 @@ export type Quote = RSComponents['schemas']['quote']
 type QuoteArgsBase = {
   receiver: RSOperations['create-quote']['requestBody']['content']['application/json']['receiver']
 }
-type QuoteArgsWithSendAmount = QuoteArgsBase & {
-  sendAmount?: RSComponents['schemas']['quote']['maxSendAmount']
+type QuoteArgsWithDebitAmount = QuoteArgsBase & {
+  debitAmount?: RSComponents['schemas']['quote']['debitAmount']
   receiveAmount?: never
 }
 type QuoteArgsWithReceiveAmount = QuoteArgsBase & {
-  sendAmount?: never
+  debitAmount?: never
   receiveAmount?: RSComponents['schemas']['quote']['receiveAmount']
 }
 export type CreateQuoteArgs =
-  | QuoteArgsWithSendAmount
+  | QuoteArgsWithDebitAmount
   | QuoteArgsWithReceiveAmount
 
 export const getASPath = <P extends keyof ASPaths>(path: P): string =>


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
- updates resource server spec and auth server spec to change `sendAmount` to `debitAmount`

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
We originally planned to add fees to the OP resources, however, we decided that fees should be included in the `debitAmount`. The difference in `debitAmount - receiveAmount` can be considered being the fees. The ASE may list those fees separately on the consent screen displayed to the user. 

- fixes #274 
