### PR TITLE
feat: making interact property optional for grant requests

### DIFF
--- a/.changeset/rare-dragons-sing.md
+++ b/.changeset/rare-dragons-sing.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Making interact property optional for grant requests

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -76,7 +76,7 @@ export type Grant = {
 export type GrantRequest = {
   access_token: ASOperations['post-request']['requestBody']['content']['application/json']['access_token']
   client: ASOperations['post-request']['requestBody']['content']['application/json']['client']
-  interact: ASOperations['post-request']['requestBody']['content']['application/json']['interact']
+  interact?: ASOperations['post-request']['requestBody']['content']['application/json']['interact']
 }
 export type GrantContinuationRequest = {
   interact_ref: ASOperations['post-continue']['requestBody']['content']['application/json']['interact_ref']


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

- Making `interact` property optional in grant requests for the open payments client to correctly match the Open Payments spec

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
Fixes #281 