### PR TITLE
feat(http-signature-utils): add functionality to load a base64 encoded private key

### DIFF
--- a/.changeset/thick-deers-sell.md
+++ b/.changeset/thick-deers-sell.md
@@ -1,0 +1,5 @@
+---
+'@interledger/http-signature-utils': minor
+---
+
+adds loadBase64Key

--- a/packages/http-signature-utils/README.md
+++ b/packages/http-signature-utils/README.md
@@ -25,6 +25,14 @@ Load or generate a private Ed25519 key:
 const key = parseOrProvisionKey('/PATH/TO/private-key.pem')
 ```
 
+Load a base64 encoded Ed25519 private key:
+
+```ts
+const key = loadBase64Key(
+  'LS0tLS1CRUdJTiBQUklWQVRFIEtFWS0tLS0tCk1DNENBUUF3QlFZREsyVndCQ0lFSUkvWHBwdkZPOWltNE9odWkxNytVMnpWNUNuMDJBWXBZWFpwcUlSQ1M0UFkKLS0tLS1FTkQgUFJJVkFURSBLRVktLS0tLQo='
+)
+```
+
 Create JWK from private Ed25519 key:
 
 ```ts

--- a/packages/http-signature-utils/src/index.ts
+++ b/packages/http-signature-utils/src/index.ts
@@ -1,6 +1,6 @@
 export { createHeaders, getKeyId, Headers } from './utils/headers'
 export { generateJwk, JWK } from './utils/jwk'
-export { parseOrProvisionKey } from './utils/key'
+export { parseOrProvisionKey, loadBase64Key } from './utils/key'
 export { createSignatureHeaders } from './utils/signatures'
 export { validateSignatureHeaders, validateSignature } from './utils/validation'
 export { generateTestKeys, TestKeys } from './test-utils/keys'

--- a/packages/http-signature-utils/src/utils/key.test.ts
+++ b/packages/http-signature-utils/src/utils/key.test.ts
@@ -102,20 +102,24 @@ describe('Key methods', (): void => {
   })
 
   describe('loadBase64Key', (): void => {
-    let key: crypto.keyObject
-    let base64Key: string
-    beforeEach(async (): Promise<void> => {
-      key = parseOrProvisionKey(undefined)
-      const privateKey = key.export({ type: 'pkcs8', format: 'pem' })
-      base64Key = Buffer.from(privateKey).toString('base64')
-      console.log(base64Key)
-    })
-
     test('can load base64 encoded key', (): void => {
+      const key = parseOrProvisionKey(undefined)
+      const privateKey = key.export({ type: 'pkcs8', format: 'pem' })
+      const base64Key = Buffer.from(privateKey).toString('base64')
       const loadedKey = loadBase64Key(base64Key)
       expect(loadedKey.export({ format: 'jwk' })).toEqual(
         key.export({ format: 'jwk' })
       )
+    })
+
+    test('returns undefined if not Ed25519 key', (): void => {
+      const key = crypto.generateKeyPairSync('rsa', {
+        modulusLength: 2048
+      }).privateKey
+      const privateKey = key.export({ type: 'pkcs8', format: 'pem' })
+      const base64Key = Buffer.from(privateKey).toString('base64')
+      const loadedKey = loadBase64Key(base64Key)
+      expect(loadedKey).toBeUndefined()
     })
   })
 })

--- a/packages/http-signature-utils/src/utils/key.test.ts
+++ b/packages/http-signature-utils/src/utils/key.test.ts
@@ -1,20 +1,20 @@
 import * as assert from 'assert'
 import * as crypto from 'crypto'
 import * as fs from 'fs'
-import { parseOrProvisionKey } from './key'
+import { Buffer } from 'buffer'
+import { loadBase64Key, parseOrProvisionKey } from './key'
 
-describe('Config', (): void => {
+describe('Key methods', (): void => {
+  const TMP_DIR = './tmp'
+
+  beforeEach(async (): Promise<void> => {
+    fs.rmSync(TMP_DIR, { recursive: true, force: true })
+  })
+
+  afterEach(async (): Promise<void> => {
+    fs.rmSync(TMP_DIR, { recursive: true, force: true })
+  })
   describe('parseOrProvisionKey', (): void => {
-    const TMP_DIR = './tmp'
-
-    beforeEach(async (): Promise<void> => {
-      fs.rmSync(TMP_DIR, { recursive: true, force: true })
-    })
-
-    afterEach(async (): Promise<void> => {
-      fs.rmSync(TMP_DIR, { recursive: true, force: true })
-    })
-
     test.each`
       tmpDirExists
       ${false}
@@ -98,6 +98,24 @@ describe('Config', (): void => {
       expect(keyfiles.length).toEqual(2)
       expect(keyfiles.filter((f) => f.startsWith('private')).length).toEqual(1)
       expect(fs.statSync(keyfile).mtimeMs).toEqual(fileStats.mtimeMs)
+    })
+  })
+
+  describe('loadBase64Key', (): void => {
+    let key: crypto.keyObject
+    let base64Key: string
+    beforeEach(async (): Promise<void> => {
+      key = parseOrProvisionKey(undefined)
+      const privateKey = key.export({ type: 'pkcs8', format: 'pem' })
+      base64Key = Buffer.from(privateKey).toString('base64')
+      console.log(base64Key)
+    })
+
+    test('can load base64 encoded key', (): void => {
+      const loadedKey = loadBase64Key(base64Key)
+      expect(loadedKey.export({ format: 'jwk' })).toEqual(
+        key.export({ format: 'jwk' })
+      )
     })
   })
 })

--- a/packages/http-signature-utils/src/utils/key.test.ts
+++ b/packages/http-signature-utils/src/utils/key.test.ts
@@ -104,9 +104,11 @@ describe('Key methods', (): void => {
   describe('loadBase64Key', (): void => {
     test('can load base64 encoded key', (): void => {
       const key = parseOrProvisionKey(undefined)
-      const privateKey = key.export({ type: 'pkcs8', format: 'pem' })
-      const base64Key = Buffer.from(privateKey).toString('base64')
-      const loadedKey = loadBase64Key(base64Key)
+      const loadedKey = loadBase64Key(
+        Buffer.from(key.export({ type: 'pkcs8', format: 'pem' })).toString(
+          'base64'
+        )
+      )
       expect(loadedKey.export({ format: 'jwk' })).toEqual(
         key.export({ format: 'jwk' })
       )
@@ -116,9 +118,11 @@ describe('Key methods', (): void => {
       const key = crypto.generateKeyPairSync('rsa', {
         modulusLength: 2048
       }).privateKey
-      const privateKey = key.export({ type: 'pkcs8', format: 'pem' })
-      const base64Key = Buffer.from(privateKey).toString('base64')
-      const loadedKey = loadBase64Key(base64Key)
+      const loadedKey = loadBase64Key(
+        Buffer.from(key.export({ type: 'pkcs8', format: 'pem' })).toString(
+          'base64'
+        )
+      )
       expect(loadedKey).toBeUndefined()
     })
   })

--- a/packages/http-signature-utils/src/utils/key.ts
+++ b/packages/http-signature-utils/src/utils/key.ts
@@ -8,8 +8,7 @@ export function parseOrProvisionKey(
   if (keyFile) {
     try {
       const key = crypto.createPrivateKey(fs.readFileSync(keyFile))
-      const jwk = key.export({ format: 'jwk' })
-      if (jwk.crv === 'Ed25519') {
+      if (checkKey(key)) {
         console.log(`Key ${keyFile} loaded.`)
         return key
       } else {
@@ -29,4 +28,17 @@ export function parseOrProvisionKey(
     keypair.privateKey.export({ format: 'pem', type: 'pkcs8' })
   )
   return keypair.privateKey
+}
+
+export function loadBase64Key(base64Key: string): crypto.KeyObject | undefined {
+  const privateKey = Buffer.from(base64Key, 'base64').toString('utf-8')
+  const key = crypto.createPrivateKey(privateKey)
+  if (checkKey(key)) {
+    return key
+  }
+}
+
+function checkKey(key: crypto.KeyObject): boolean {
+  const jwk = key.export({ format: 'jwk' })
+  return jwk.crv === 'Ed25519'
 }


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Adds `loadBase64Key` to http-signature-utils

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
