### PR TITLE
fix: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/interledger/open-payments/master/landing/public/Open_Payments_standard_logo.svg" width="700" alt="Open Payments">
+  <img src="https://raw.githubusercontent.com/interledger/open-payments/main/docs/public/img/logo.svg" width="700" alt="Open Payments">
 </p>
 
 ---


### PR DESCRIPTION
After migrating the site over to Starlight, the original logo path on the README no longer exists. This PR updates the image path to point to where the logo lives now.