### PR TITLE
fix: update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ APIs.
 This repository hosts the Open API Specifications of the two APIs which are published along with additional documentation at
 https://docs.openpayments.guide.
 
-The code for the landing [page](https://openpayments.guide) is in `./landing`.
+The code for the landing [page](https://openpayments.guide) is in `./docs`.
 
 ## Dependencies
 


### PR DESCRIPTION
This PR fixes a non-existent link in the README now that we have replaced the old landing page.