### PR TITLE
fix(openapi): add base url

### DIFF
--- a/.changeset/loud-snakes-melt.md
+++ b/.changeset/loud-snakes-melt.md
@@ -1,5 +1,0 @@
----
-'@interledger/open-payments': major
----
-
-Changes base path from / to /openpayments.guide

--- a/.changeset/loud-snakes-melt.md
+++ b/.changeset/loud-snakes-melt.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': major
+---
+
+Changes base path from / to /openpayments.guide

--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -10,7 +10,7 @@ info:
   contact:
     email: tech@interledger.org
 servers:
-  - url: 'https://openpayments.guide/auth'
+  - url: 'https://rafiki.money/auth'
 tags:
   - name: grant
     description: Grant operations
@@ -49,29 +49,29 @@ paths:
                 Interaction instructions:
                   value:
                     interact:
-                      redirect: 'https://openpayments.guide/auth/4CF492MLVMSW9MKMXKHQ'
+                      redirect: 'https://rafiki.money/auth/4CF492MLVMSW9MKMXKHQ'
                       finish: 4105340a-05eb-4290-8739-f9e2b463bfa7
                     continue:
                       access_token:
                         value: 33OMUKMKSKU80UPRY5NM
-                      uri: 'https://openpayments.guide/auth/continue/4CF492MLVMSW9MKMXKHQ'
+                      uri: 'https://rafiki.money/auth/continue/4CF492MLVMSW9MKMXKHQ'
                       wait: 30
                 Grant:
                   value:
                     access_token:
                       value: OS9M2PMHKUR64TB8N6BW7OZB8CDFONP219RP1LT0
-                      manage: 'https://openpayments.guide/auth/token/dd17a202-9982-4ed9-ae31-564947fb6379'
+                      manage: 'https://rafiki.money/auth/token/dd17a202-9982-4ed9-ae31-564947fb6379'
                       expires_in: 3600
                       access:
                         - type: incoming-payment
                           actions:
                             - create
                             - read
-                          identifier: 'https://openpayments.guide/bob'
+                          identifier: 'https://rafiki.money/bob'
                     continue:
                       access_token:
                         value: 33OMUKMKSKU80UPRY5NM
-                      uri: 'https://openpayments.guide/auth/continue/4CF492MLVMSW9MKMXKHQ'
+                      uri: 'https://rafiki.money/auth/continue/4CF492MLVMSW9MKMXKHQ'
         '400':
           description: Bad Request
         '401':
@@ -108,9 +108,9 @@ paths:
                         actions:
                           - create
                           - read
-                        identifier: 'https://openpayments.guide/alice'
+                        identifier: 'https://rafiki.money/alice'
                         limits:
-                          receiver: 'https://openpayments.guide/connections/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
+                          receiver: 'https://rafiki.money/connections/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                           interval: 'R12/2019-08-24T14:15:22Z/P1M'
                           debitAmount:
                             value: '500'
@@ -132,7 +132,7 @@ paths:
                         actions:
                           - create
                           - read
-                        identifier: 'http://openpayments.guide/bob'
+                        identifier: 'http://rafiki.money/bob'
                   client: 'https://webmonize.com/.well-known/pay'
         description: ''
       description: Make a new grant request
@@ -169,16 +169,16 @@ paths:
                   value:
                     access_token:
                       value: OS9M2PMHKUR64TB8N6BW7OZB8CDFONP219RP1LT0
-                      manage: 'https://openpayments.guide/auth/token/dd17a202-9982-4ed9-ae31-564947fb6379'
+                      manage: 'https://rafiki.money/auth/token/dd17a202-9982-4ed9-ae31-564947fb6379'
                       expires_in: 3600
                       access:
                         - type: outgoing-payment
                           actions:
                             - create
                             - read
-                          identifier: 'https://openpayments.guide/alice'
+                          identifier: 'https://rafiki.money/alice'
                           limits:
-                            receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
+                            receiver: 'https://rafiki.money/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
                             interval: 'R12/2019-08-24T14:15:22Z/P1M'
                             debitAmount:
                               value: '500'
@@ -187,14 +187,14 @@ paths:
                     continue:
                       access_token:
                         value: 33OMUKMKSKU80UPRY5NM
-                      uri: 'https://openpayments.guide/auth/continue/4CF492MLVMSW9MKMXKHQ'
+                      uri: 'https://rafiki.money/auth/continue/4CF492MLVMSW9MKMXKHQ'
                       wait: 30
                 Continuing During Pending Interaction:
                   value:
                     continue:
                       access_token:
                         value: 33OMUKMKSKU80UPRY5NM
-                      uri: 'https://openpayments.guide/auth/continue/4CF492MLVMSW9MKMXKHQ'
+                      uri: 'https://rafiki.money/auth/continue/4CF492MLVMSW9MKMXKHQ'
                       wait: 30
         '400':
           description: Bad Request
@@ -264,17 +264,17 @@ paths:
                   value:
                     access_token:
                       value: OZB8CDFONP219RP1LT0OS9M2PMHKUR64TB8N6BW7
-                      manage: 'https://openpayments.guide/auth/token/8f69de01-5bf9-4603-91ed-eeca101081f1'
+                      manage: 'https://rafiki.money/auth/token/8f69de01-5bf9-4603-91ed-eeca101081f1'
                       expires_in: 3600
                       access:
                         - type: outgoing-payment
                           actions:
                             - create
                             - read
-                          identifier: 'https://openpayments.guide/alice'
+                          identifier: 'https://rafiki.money/alice'
                           limits:
                             interval: 'R12/2019-08-24T14:15:22Z/P1M'
-                            receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
+                            receiver: 'https://rafiki.money/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
                             debitAmount:
                               value: '500'
                               assetCode: USD

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -32,8 +32,8 @@ info:
   contact:
     email: tech@interledger.org
 servers:
-  - url: 'https://openpayments/'
-    description: 'Server for wallet address subresources or Connection resources (ie https://openpayments.guide/)'
+  - url: 'https://openpayments.guide'
+    description: 'Server for wallet address subresources or Connection resources (ie https://openpayments.guide/alice)'
 tags:
   - name: wallet-address
     description: wallet address operations
@@ -59,9 +59,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/wallet-address'
               examples:
-                Get wallet address for $openpayments.guide/:
+                Get wallet address for $openpayments.guide/alice:
                   value:
-                    id: 'https://openpayments.guide/'
+                    id: 'https://openpayments.guide/alice'
                     publicName: Alice
                     assetCode: USD
                     assetScale: 2
@@ -112,7 +112,7 @@ paths:
                 New Incoming Payment for $25:
                   value:
                     id: 'https://openpayments.guide/incoming-payments/08394f02-7b7b-45e2-b645-51d04e7c330c'
-                    walletAddress: 'https://openpayments.guide/'
+                    walletAddress: 'https://openpayments.guide/alice/'
                     incomingAmount:
                       value: '2500'
                       assetCode: USD
@@ -205,7 +205,7 @@ paths:
                       hasNextPage: true
                     result:
                       - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         incomingAmount:
                           value: '250'
                           assetCode: USD
@@ -222,7 +222,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         completed: true
                       - id: 'https://openpayments.guide/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         receivedAmount:
                           value: '100'
                           assetCode: USD
@@ -242,7 +242,7 @@ paths:
                       hasNextPage: false
                     result:
                       - id: 'https://openpayments.guide/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         receivedAmount:
                           value: '100'
                           assetCode: USD
@@ -254,7 +254,7 @@ paths:
                         metadata:
                           description: 'I love your website, Alice! Thanks for the great content'
                       - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         incomingAmount:
                           value: '250'
                           assetCode: USD
@@ -300,7 +300,7 @@ paths:
                 New Fixed Send Outgoing Payment for $25:
                   value:
                     id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                    walletAddress: 'https://openpayments.guide/'
+                    walletAddress: 'https://openpayments.guide/alice/'
                     failed: false
                     receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
                     debitAmount:
@@ -386,7 +386,7 @@ paths:
                       hasNextPage: true
                     result:
                       - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                         receiveAmount:
@@ -407,7 +407,7 @@ paths:
                           description: APlusVideo subscription
                           externalRef: 'customer: 847458475'
                       - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
                         debitAmount:
@@ -436,7 +436,7 @@ paths:
                       hasNextPage: false
                     result:
                       - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
                         debitAmount:
@@ -457,7 +457,7 @@ paths:
                           description: Thank you for your purchase at ShoeShop!
                           externalRef: INV2022-8943756
                       - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                        walletAddress: 'https://openpayments.guide/'
+                        walletAddress: 'https://openpayments.guide/alice/'
                         failed: false
                         receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                         receiveAmount:
@@ -507,7 +507,7 @@ paths:
                 New Fixed Send Quote for $25:
                   value:
                     id: 'https://openpayments.guide/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                    walletAddress: 'https://openpayments.guide/'
+                    walletAddress: 'https://openpayments.guide/alice/'
                     receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                     debitAmount:
                       value: '2500'
@@ -603,7 +603,7 @@ paths:
                 Incoming Payment for $25 with $12.34 received so far:
                   value:
                     id: 'https://openpayments.guide/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
-                    walletAddress: 'https://openpayments.guide/'
+                    walletAddress: 'https://openpayments.guide/alice/'
                     incomingAmount:
                       value: '2500'
                       assetCode: USD
@@ -649,7 +649,7 @@ paths:
                 Completed Incoming Payment:
                   value:
                     id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                    walletAddress: 'https://openpayments.guide/'
+                    walletAddress: 'https://openpayments.guide/alice/'
                     incomingAmount:
                       value: '250'
                       assetCode: USD
@@ -778,7 +778,7 @@ components:
       description: A **wallet address** resource is the root of the API and contains the public details of the financial account represented by the Wallet Address that is also the service endpoint URL.
       additionalProperties: false
       examples:
-        - id: 'https://openpayments.guide/'
+        - id: 'https://openpayments.guide/alice'
           publicName: Alice
           assetCode: USD
           assetScale: 2
@@ -834,7 +834,7 @@ components:
       type: object
       examples:
         - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-          walletAddress: 'https://openpayments.guide/'
+          walletAddress: 'https://openpayments.guide/alice/'
           incomingAmount:
             value: '250'
             assetCode: USD
@@ -851,7 +851,7 @@ components:
             description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
             externalRef: Coffee w/ Mo on 10 March 22
         - id: 'https://openpayments.guide/incoming-payments/456da9d5-c9a4-4c80-a354-86b915a04ff8'
-          walletAddress: 'https://openpayments.guide/'
+          walletAddress: 'https://openpayments.guide/alice/'
           incomingAmount:
             value: '2500'
             assetCode: USD
@@ -926,7 +926,7 @@ components:
       type: object
       examples:
         - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-          walletAddress: 'https://openpayments.guide/'
+          walletAddress: 'https://openpayments.guide/alice/'
           failed: false
           receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
           receiveAmount:
@@ -947,7 +947,7 @@ components:
             description: APlusVideo subscription
             externalRef: 'customer: 847458475'
         - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-          walletAddress: 'https://openpayments.guide/'
+          walletAddress: 'https://openpayments.guide/alice/'
           failed: false
           receiver: 'https://openpayments.guide/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
           debitAmount:
@@ -1022,7 +1022,7 @@ components:
       type: object
       examples:
         - id: 'https://openpayments.guide/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
-          walletAddress: 'https://openpayments.guide/'
+          walletAddress: 'https://openpayments.guide/alice/'
           receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
           receiveAmount:
             value: '2500'
@@ -1039,7 +1039,7 @@ components:
           createdAt: '2022-03-12T23:20:50.52Z'
           expiresAt: '2022-04-12T23:20:50.52Z'
         - id: 'https://openpayments.guide/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-          walletAddress: 'https://openpayments.guide/'
+          walletAddress: 'https://openpayments.guide/alice/'
           receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
           debitAmount:
             value: '7126'

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -32,8 +32,8 @@ info:
   contact:
     email: tech@interledger.org
 servers:
-  - url: 'https://openpayments.guide'
-    description: 'Server for wallet address subresources or Connection resources (ie https://openpayments.guide/alice)'
+  - url: 'https://openpayments/'
+    description: 'Server for wallet address subresources or Connection resources (ie https://openpayments.guide/)'
 tags:
   - name: wallet-address
     description: wallet address operations
@@ -59,9 +59,9 @@ paths:
               schema:
                 $ref: '#/components/schemas/wallet-address'
               examples:
-                Get wallet address for $openpayments.guide/alice:
+                Get wallet address for $openpayments.guide/:
                   value:
-                    id: 'https://openpayments.guide/alice'
+                    id: 'https://openpayments.guide/'
                     publicName: Alice
                     assetCode: USD
                     assetScale: 2
@@ -112,7 +112,7 @@ paths:
                 New Incoming Payment for $25:
                   value:
                     id: 'https://openpayments.guide/incoming-payments/08394f02-7b7b-45e2-b645-51d04e7c330c'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    walletAddress: 'https://openpayments.guide/'
                     incomingAmount:
                       value: '2500'
                       assetCode: USD
@@ -205,7 +205,7 @@ paths:
                       hasNextPage: true
                     result:
                       - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         incomingAmount:
                           value: '250'
                           assetCode: USD
@@ -222,7 +222,7 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         completed: true
                       - id: 'https://openpayments.guide/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         receivedAmount:
                           value: '100'
                           assetCode: USD
@@ -242,7 +242,7 @@ paths:
                       hasNextPage: false
                     result:
                       - id: 'https://openpayments.guide/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         receivedAmount:
                           value: '100'
                           assetCode: USD
@@ -254,7 +254,7 @@ paths:
                         metadata:
                           description: 'I love your website, Alice! Thanks for the great content'
                       - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         incomingAmount:
                           value: '250'
                           assetCode: USD
@@ -300,7 +300,7 @@ paths:
                 New Fixed Send Outgoing Payment for $25:
                   value:
                     id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    walletAddress: 'https://openpayments.guide/'
                     failed: false
                     receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
                     debitAmount:
@@ -386,7 +386,7 @@ paths:
                       hasNextPage: true
                     result:
                       - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         failed: false
                         receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                         receiveAmount:
@@ -407,7 +407,7 @@ paths:
                           description: APlusVideo subscription
                           externalRef: 'customer: 847458475'
                       - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
                         debitAmount:
@@ -436,7 +436,7 @@ paths:
                       hasNextPage: false
                     result:
                       - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         failed: false
                         receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
                         debitAmount:
@@ -457,7 +457,7 @@ paths:
                           description: Thank you for your purchase at ShoeShop!
                           externalRef: INV2022-8943756
                       - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                        walletAddress: 'https://openpayments.guide/'
                         failed: false
                         receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                         receiveAmount:
@@ -507,7 +507,7 @@ paths:
                 New Fixed Send Quote for $25:
                   value:
                     id: 'https://openpayments.guide/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    walletAddress: 'https://openpayments.guide/'
                     receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                     debitAmount:
                       value: '2500'
@@ -603,7 +603,7 @@ paths:
                 Incoming Payment for $25 with $12.34 received so far:
                   value:
                     id: 'https://openpayments.guide/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    walletAddress: 'https://openpayments.guide/'
                     incomingAmount:
                       value: '2500'
                       assetCode: USD
@@ -649,7 +649,7 @@ paths:
                 Completed Incoming Payment:
                   value:
                     id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    walletAddress: 'https://openpayments.guide/'
                     incomingAmount:
                       value: '250'
                       assetCode: USD
@@ -778,7 +778,7 @@ components:
       description: A **wallet address** resource is the root of the API and contains the public details of the financial account represented by the Wallet Address that is also the service endpoint URL.
       additionalProperties: false
       examples:
-        - id: 'https://openpayments.guide/alice'
+        - id: 'https://openpayments.guide/'
           publicName: Alice
           assetCode: USD
           assetScale: 2
@@ -834,7 +834,7 @@ components:
       type: object
       examples:
         - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-          walletAddress: 'https://openpayments.guide/alice/'
+          walletAddress: 'https://openpayments.guide/'
           incomingAmount:
             value: '250'
             assetCode: USD
@@ -851,7 +851,7 @@ components:
             description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
             externalRef: Coffee w/ Mo on 10 March 22
         - id: 'https://openpayments.guide/incoming-payments/456da9d5-c9a4-4c80-a354-86b915a04ff8'
-          walletAddress: 'https://openpayments.guide/alice/'
+          walletAddress: 'https://openpayments.guide/'
           incomingAmount:
             value: '2500'
             assetCode: USD
@@ -926,7 +926,7 @@ components:
       type: object
       examples:
         - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-          walletAddress: 'https://openpayments.guide/alice/'
+          walletAddress: 'https://openpayments.guide/'
           failed: false
           receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
           receiveAmount:
@@ -947,7 +947,7 @@ components:
             description: APlusVideo subscription
             externalRef: 'customer: 847458475'
         - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-          walletAddress: 'https://openpayments.guide/alice/'
+          walletAddress: 'https://openpayments.guide/'
           failed: false
           receiver: 'https://openpayments.guide/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
           debitAmount:
@@ -1022,7 +1022,7 @@ components:
       type: object
       examples:
         - id: 'https://openpayments.guide/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
-          walletAddress: 'https://openpayments.guide/alice/'
+          walletAddress: 'https://openpayments.guide/'
           receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
           receiveAmount:
             value: '2500'
@@ -1039,7 +1039,7 @@ components:
           createdAt: '2022-03-12T23:20:50.52Z'
           expiresAt: '2022-04-12T23:20:50.52Z'
         - id: 'https://openpayments.guide/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-          walletAddress: 'https://openpayments.guide/alice/'
+          walletAddress: 'https://openpayments.guide/'
           receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
           debitAmount:
             value: '7126'

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -32,8 +32,8 @@ info:
   contact:
     email: tech@interledger.org
 servers:
-  - url: 'https://openpayments.guide'
-    description: 'Server for wallet address subresources or Connection resources (ie https://openpayments.guide/alice)'
+  - url: 'https://rafiki.money'
+    description: 'Server for wallet address subresources or Connection resources (ie https://rafiki.money/alice)'
 tags:
   - name: wallet-address
     description: wallet address operations
@@ -59,13 +59,13 @@ paths:
               schema:
                 $ref: '#/components/schemas/wallet-address'
               examples:
-                Get wallet address for $openpayments.guide/alice:
+                Get wallet address for $rafiki.money/alice:
                   value:
-                    id: 'https://openpayments.guide/alice'
+                    id: 'https://rafiki.money/alice'
                     publicName: Alice
                     assetCode: USD
                     assetScale: 2
-                    authServer: 'https://openpayments.guide/auth'
+                    authServer: 'https://rafiki.money/auth'
         '404':
           description: Wallet Address Not Found
       operationId: get-wallet-address
@@ -111,8 +111,8 @@ paths:
               examples:
                 New Incoming Payment for $25:
                   value:
-                    id: 'https://openpayments.guide/incoming-payments/08394f02-7b7b-45e2-b645-51d04e7c330c'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    id: 'https://rafiki.money/incoming-payments/08394f02-7b7b-45e2-b645-51d04e7c330c'
+                    walletAddress: 'https://rafiki.money/alice/'
                     incomingAmount:
                       value: '2500'
                       assetCode: USD
@@ -204,8 +204,8 @@ paths:
                       hasPreviousPage: false
                       hasNextPage: true
                     result:
-                      - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
+                        walletAddress: 'https://rafiki.money/alice/'
                         incomingAmount:
                           value: '250'
                           assetCode: USD
@@ -221,8 +221,8 @@ paths:
                         createdAt: '2022-03-12T23:20:50.52Z'
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         completed: true
-                      - id: 'https://openpayments.guide/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
+                        walletAddress: 'https://rafiki.money/alice/'
                         receivedAmount:
                           value: '100'
                           assetCode: USD
@@ -241,8 +241,8 @@ paths:
                       hasPreviousPage: true
                       hasNextPage: false
                     result:
-                      - id: 'https://openpayments.guide/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/incoming-payments/32abc219-3dc3-44ec-a225-790cacfca8fa'
+                        walletAddress: 'https://rafiki.money/alice/'
                         receivedAmount:
                           value: '100'
                           assetCode: USD
@@ -253,8 +253,8 @@ paths:
                         updatedAt: '2022-04-01T10:24:36.11Z'
                         metadata:
                           description: 'I love your website, Alice! Thanks for the great content'
-                      - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
+                        walletAddress: 'https://rafiki.money/alice/'
                         incomingAmount:
                           value: '250'
                           assetCode: USD
@@ -299,10 +299,10 @@ paths:
               examples:
                 New Fixed Send Outgoing Payment for $25:
                   value:
-                    id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    id: 'https://rafiki.money/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+                    walletAddress: 'https://rafiki.money/alice/'
                     failed: false
-                    receiver: 'https://openpayments.guide/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
+                    receiver: 'https://rafiki.money/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2'
                     debitAmount:
                       value: '2600'
                       assetCode: USD
@@ -329,7 +329,7 @@ paths:
             examples:
               Create an outgoing payment based on a quote:
                 value:
-                  quoteId: 'https://openpayments.guide/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
+                  quoteId: 'https://rafiki.money/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
                   metadata:
                     externalRef: INV2022-02-0137
             schema:
@@ -385,10 +385,10 @@ paths:
                       hasPreviousPage: false
                       hasNextPage: true
                     result:
-                      - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+                        walletAddress: 'https://rafiki.money/alice/'
                         failed: false
-                        receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
+                        receiver: 'https://rafiki.money/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                         receiveAmount:
                           value: '2500'
                           assetCode: USD
@@ -406,10 +406,10 @@ paths:
                         metadata:
                           description: APlusVideo subscription
                           externalRef: 'customer: 847458475'
-                      - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
+                        walletAddress: 'https://rafiki.money/alice/'
                         failed: false
-                        receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
+                        receiver: 'https://rafiki.money/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
                         debitAmount:
                           value: '7126'
                           assetCode: USD
@@ -435,10 +435,10 @@ paths:
                       hasPreviousPage: true
                       hasNextPage: false
                     result:
-                      - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
+                        walletAddress: 'https://rafiki.money/alice/'
                         failed: false
-                        receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
+                        receiver: 'https://rafiki.money/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
                         debitAmount:
                           value: '7126'
                           assetCode: USD
@@ -456,10 +456,10 @@ paths:
                         metadata:
                           description: Thank you for your purchase at ShoeShop!
                           externalRef: INV2022-8943756
-                      - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                        walletAddress: 'https://openpayments.guide/alice/'
+                      - id: 'https://rafiki.money/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+                        walletAddress: 'https://rafiki.money/alice/'
                         failed: false
-                        receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
+                        receiver: 'https://rafiki.money/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                         receiveAmount:
                           value: '2500'
                           assetCode: USD
@@ -506,9 +506,9 @@ paths:
               examples:
                 New Fixed Send Quote for $25:
                   value:
-                    id: 'https://openpayments.guide/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-                    walletAddress: 'https://openpayments.guide/alice/'
-                    receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
+                    id: 'https://rafiki.money/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+                    walletAddress: 'https://rafiki.money/alice/'
+                    receiver: 'https://rafiki.money/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
                     debitAmount:
                       value: '2500'
                       assetCode: USD
@@ -531,14 +531,14 @@ paths:
             examples:
               Create fixed-send-amount quote for $25 to an ILP STREAM connection:
                 value:
-                  receiver: 'https://openpayments.guide/connections/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
+                  receiver: 'https://rafiki.money/connections/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                   debitAmount:
                     value: '2500'
                     assetCode: USD
                     assetScale: 2
               Create fixed-receive-amount quote for $25:
                 value:
-                  receiver: 'https://openpayments.guide/incoming-payments/37a0d0ee-26dc-4c66-89e0-01fbf93156f7'
+                  receiver: 'https://rafiki.money/incoming-payments/37a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                   receiveAmount:
                     value: '2500'
                     assetCode: USD
@@ -602,8 +602,8 @@ paths:
               examples:
                 Incoming Payment for $25 with $12.34 received so far:
                   value:
-                    id: 'https://openpayments.guide/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    id: 'https://rafiki.money/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
+                    walletAddress: 'https://rafiki.money/alice/'
                     incomingAmount:
                       value: '2500'
                       assetCode: USD
@@ -648,8 +648,8 @@ paths:
               examples:
                 Completed Incoming Payment:
                   value:
-                    id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-                    walletAddress: 'https://openpayments.guide/alice/'
+                    id: 'https://rafiki.money/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
+                    walletAddress: 'https://rafiki.money/alice/'
                     incomingAmount:
                       value: '250'
                       assetCode: USD
@@ -696,10 +696,10 @@ paths:
               examples:
                 Outgoing Payment with a fixed send amount of $25:
                   value:
-                    id: 'https://openpayments.guide/bob/outgoing-payments/3859b39e-4666-4ce5-8745-72f1864c5371'
-                    walletAddress: 'https://openpayments.guide/bob/'
+                    id: 'https://rafiki.money/bob/outgoing-payments/3859b39e-4666-4ce5-8745-72f1864c5371'
+                    walletAddress: 'https://rafiki.money/bob/'
                     failed: false
-                    receiver: 'https://openpayments.guide/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
+                    receiver: 'https://rafiki.money/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
                     debitAmount:
                       value: '2500'
                       assetCode: USD
@@ -745,9 +745,9 @@ paths:
               examples:
                 Quote with a fixed send amount of $25:
                   value:
-                    id: 'https://openpayments.guide/bob/quotes/3859b39e-4666-4ce5-8745-72f1864c5371'
-                    walletAddress: 'https://openpayments.guide/bob/'
-                    receiver: 'https://openpayments.guide/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
+                    id: 'https://rafiki.money/bob/quotes/3859b39e-4666-4ce5-8745-72f1864c5371'
+                    walletAddress: 'https://rafiki.money/bob/'
+                    receiver: 'https://rafiki.money/incoming-payments/2f1b0150-db73-49e8-8713-628baa4a17ff'
                     debitAmount:
                       value: '2500'
                       assetCode: USD
@@ -778,11 +778,11 @@ components:
       description: A **wallet address** resource is the root of the API and contains the public details of the financial account represented by the Wallet Address that is also the service endpoint URL.
       additionalProperties: false
       examples:
-        - id: 'https://openpayments.guide/alice'
+        - id: 'https://rafiki.money/alice'
           publicName: Alice
           assetCode: USD
           assetScale: 2
-          authServer: 'https://openpayments.guide/auth'
+          authServer: 'https://rafiki.money/auth'
       properties:
         id:
           type: string
@@ -833,8 +833,8 @@ components:
       description: 'An **incoming payment** resource represents a payment that will be, is currently being, or has been received by the account.'
       type: object
       examples:
-        - id: 'https://openpayments.guide/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
-          walletAddress: 'https://openpayments.guide/alice/'
+        - id: 'https://rafiki.money/incoming-payments/016da9d5-c9a4-4c80-a354-86b915a04ff8'
+          walletAddress: 'https://rafiki.money/alice/'
           incomingAmount:
             value: '250'
             assetCode: USD
@@ -850,8 +850,8 @@ components:
           metadata:
             description: 'Hi Mo, this is for the cappuccino I bought for you the other day.'
             externalRef: Coffee w/ Mo on 10 March 22
-        - id: 'https://openpayments.guide/incoming-payments/456da9d5-c9a4-4c80-a354-86b915a04ff8'
-          walletAddress: 'https://openpayments.guide/alice/'
+        - id: 'https://rafiki.money/incoming-payments/456da9d5-c9a4-4c80-a354-86b915a04ff8'
+          walletAddress: 'https://rafiki.money/alice/'
           incomingAmount:
             value: '2500'
             assetCode: USD
@@ -925,10 +925,10 @@ components:
       description: 'An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the wallet address.'
       type: object
       examples:
-        - id: 'https://openpayments.guide/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-          walletAddress: 'https://openpayments.guide/alice/'
+        - id: 'https://rafiki.money/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+          walletAddress: 'https://rafiki.money/alice/'
           failed: false
-          receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
+          receiver: 'https://rafiki.money/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
           receiveAmount:
             value: '2500'
             assetCode: USD
@@ -946,10 +946,10 @@ components:
           metadata:
             description: APlusVideo subscription
             externalRef: 'customer: 847458475'
-        - id: 'https://openpayments.guide/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-          walletAddress: 'https://openpayments.guide/alice/'
+        - id: 'https://rafiki.money/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
+          walletAddress: 'https://rafiki.money/alice/'
           failed: false
-          receiver: 'https://openpayments.guide/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
+          receiver: 'https://rafiki.money/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
           debitAmount:
             value: '7126'
             assetCode: USD
@@ -1021,9 +1021,9 @@ components:
       description: A **quote** resource represents the quoted amount details with which an Outgoing Payment may be created.
       type: object
       examples:
-        - id: 'https://openpayments.guide/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
-          walletAddress: 'https://openpayments.guide/alice/'
-          receiver: 'https://openpayments.guide/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
+        - id: 'https://rafiki.money/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
+          walletAddress: 'https://rafiki.money/alice/'
+          receiver: 'https://rafiki.money/shoeshop/incoming-payments/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
           receiveAmount:
             value: '2500'
             assetCode: USD
@@ -1038,9 +1038,9 @@ components:
             assetScale: 2
           createdAt: '2022-03-12T23:20:50.52Z'
           expiresAt: '2022-04-12T23:20:50.52Z'
-        - id: 'https://openpayments.guide/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
-          walletAddress: 'https://openpayments.guide/alice/'
-          receiver: 'https://openpayments.guide/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
+        - id: 'https://rafiki.money/quotes/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+          walletAddress: 'https://rafiki.money/alice/'
+          receiver: 'https://rafiki.money/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
           debitAmount:
             value: '7126'
             assetCode: USD

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -32,7 +32,7 @@ info:
   contact:
     email: tech@interledger.org
 servers:
-  - url: '/'
+  - url: 'https://openpayments.guide'
     description: 'Server for wallet address subresources or Connection resources (ie https://openpayments.guide/alice)'
 tags:
   - name: wallet-address


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request
- adds `rafiki.money` as base path

![image](https://github.com/interledger/open-payments/assets/12960453/27692b62-5067-490c-8e63-3ad6d98a72f0)

<!--
Provide a succinct description of what this pull request entails.
-->

## Context
- fixes https://github.com/interledger/open-payments/issues/303

The issues suggests maybe using rafiki.money as the base url but I opted for openpayments.guide because that's what it originally was. https://github.com/interledger/open-payments/blob/5d39b2ef5f202e6378555b790730f9465ecd6f97/openapi/resource-server.yaml#L35C3-L39 This makes the base url consistent with existing examples.
<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
