### PR TITLE
fix(openapi): allow additional properties in wallet address response

### DIFF
--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -54,6 +54,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/wallet-address'
+                additionalProperties: true
               examples:
                 Get wallet address for $ilp.rafiki.money/alice:
                   value:


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

Allow extra fields to be returned in the response to looking up a wallet address.

## Context
Fynbos returns a superset of the specified wallet address response. This is currently causing the lookup to fail.
