### PR TITLE
fix(open-payments): limit pagination args to relevant params

### DIFF
--- a/.changeset/cyan-jokes-travel.md
+++ b/.changeset/cyan-jokes-travel.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': patch
+---
+
+Corrects PaginationArgs to only include relevant properties from query parameters. Was previously including wallet-address as well.

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -33,16 +33,16 @@ type PaginationResult<T> = {
   result: T[]
 }
 export type OutgoingPaymentPaginationResult = PaginationResult<OutgoingPayment>
-export type ForwardPagination = Omit<
+
+type BasePaginationArgs = Pick<
   RSOperations['list-incoming-payments']['parameters']['query'],
-  'last'
-> & {
+  'first' | 'last' | 'cursor'
+>
+
+export type ForwardPagination = Omit<BasePaginationArgs, 'last'> & {
   last?: never
 }
-export type BackwardPagination = Omit<
-  RSOperations['list-incoming-payments']['parameters']['query'],
-  'first'
-> & {
+export type BackwardPagination = Omit<BasePaginationArgs, 'first'> & {
   first?: never
 }
 export type PaginationArgs = ForwardPagination | BackwardPagination


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request
- Our `PaginationArgs` type was assuming all `list-incoming-payments` query params were for pagination. After adding the `wallet-address` param this broke our `PaginationArgs` type so I changed to just explicitly use the pagination specific parameters.

<!--
Provide a succinct description of what this pull request entails.
-->

## Context
- fixes: https://github.com/interledger/rafiki/issues/2070
<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
