### PR TITLE
feat: add receiverWalletAddress to POST /quote requests

### DIFF
--- a/.changeset/chatty-poems-yell.md
+++ b/.changeset/chatty-poems-yell.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Added "receiverWalletAddress" to create quote endpoint

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -543,11 +543,13 @@ paths:
               Create quote for an `receiver` that is an Incoming Payment with an `incomingAmount`:
                 value:
                   walletAddress: 'https://ilp.rafiki.money/alice'
+                  receiverWalletAddress: 'https://ilp.rafiki.money/bob'
                   receiver: 'https://ilp.rafiki.money/incoming-payments/37a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                   method: ilp
               Create fixed-send amount quote for $25:
                 value:
                   walletAddress: 'https://ilp.rafiki.money/alice'
+                  receiverWalletAddress: 'https://ilp.rafiki.money/bob'
                   receiver: 'https://ilp.rafiki.money/incoming-payments/37a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                   method: ilp
                   debitAmount:
@@ -557,6 +559,7 @@ paths:
               Create fixed-receive amount quote for $25:
                 value:
                   walletAddress: 'https://ilp.rafiki.money/alice'
+                  receiverWalletAddress: 'https://ilp.rafiki.money/bob'
                   receiver: 'https://ilp.rafiki.money/incoming-payments/37a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                   method: ilp
                   receiveAmount:
@@ -569,18 +572,23 @@ paths:
                   properties:
                     walletAddress:
                       $ref: ./schemas.yaml#/components/schemas/walletAddress
+                    receiverWalletAddress:
+                      $ref: ./schemas.yaml#/components/schemas/walletAddress
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
                     method:
                       $ref: '#/components/schemas/payment-method'
                   required:
                     - walletAddress
+                    - receiverWalletAddress
                     - receiver
                     - method
                   additionalProperties: false
                 - description: Create a quote with a fixed-receive amount
                   properties:
                     walletAddress:
+                      $ref: ./schemas.yaml#/components/schemas/walletAddress
+                    receiverWalletAddress:
                       $ref: ./schemas.yaml#/components/schemas/walletAddress
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
@@ -591,6 +599,7 @@ paths:
                       $ref: ./schemas.yaml#/components/schemas/amount
                   required:
                     - walletAddress
+                    - receiverWalletAddress
                     - receiver
                     - method
                     - receiveAmount
@@ -598,6 +607,8 @@ paths:
                 - description: Create a quote with a fixed-send amount
                   properties:
                     walletAddress:
+                      $ref: ./schemas.yaml#/components/schemas/walletAddress
+                    receiverWalletAddress:
                       $ref: ./schemas.yaml#/components/schemas/walletAddress
                     receiver:
                       $ref: ./schemas.yaml#/components/schemas/receiver
@@ -608,6 +619,7 @@ paths:
                       $ref: ./schemas.yaml#/components/schemas/amount
                   required:
                     - walletAddress
+                    - receiverWalletAddress
                     - receiver
                     - method
                     - debitAmount

--- a/packages/open-payments/src/client/quote.test.ts
+++ b/packages/open-payments/src/client/quote.test.ts
@@ -86,7 +86,7 @@ describe('quote', (): void => {
           accessToken
         },
         openApiValidators.successfulValidator,
-        { receiver: quote.receiver, method: 'ilp', walletAddress }
+        { receiver: quote.receiver, method: 'ilp', walletAddress, receiverWalletAddress: quote.walletAddress }
       )
       expect(result).toStrictEqual(quote)
       scope.done()
@@ -105,7 +105,7 @@ describe('quote', (): void => {
             accessToken
           },
           openApiValidators.failedValidator,
-          { receiver: quote.receiver, method: 'ilp', walletAddress }
+          { receiver: quote.receiver, method: 'ilp', walletAddress, receiverWalletAddress: quote.walletAddress }
         )
       ).rejects.toThrowError()
       scope.done()
@@ -172,7 +172,7 @@ describe('quote', (): void => {
             url: baseUrl,
             accessToken
           },
-          { receiver: quote.receiver, method: 'ilp', walletAddress }
+          { receiver: quote.receiver, method: 'ilp', walletAddress, receiverWalletAddress: quote.walletAddress }
         )
 
         expect(postSpy).toHaveBeenCalledWith(
@@ -183,7 +183,7 @@ describe('quote', (): void => {
           {
             url,
             accessToken,
-            body: { receiver: quote.receiver, method: 'ilp', walletAddress }
+            body: { receiver: quote.receiver, method: 'ilp', walletAddress, receiverWalletAddress: quote.walletAddress }
           },
           true
         )

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -546,11 +546,13 @@ export interface operations {
         "application/json":
           | {
               walletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
+              receiverWalletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
               receiver: external["schemas.yaml"]["components"]["schemas"]["receiver"];
               method: components["schemas"]["payment-method"];
             }
           | {
               walletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
+              receiverWalletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
               receiver: external["schemas.yaml"]["components"]["schemas"]["receiver"];
               method: components["schemas"]["payment-method"];
               /** @description The fixed amount that would be paid into the receiving wallet address given a successful outgoing payment. */
@@ -558,6 +560,7 @@ export interface operations {
             }
           | {
               walletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
+              receiverWalletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
               receiver: external["schemas.yaml"]["components"]["schemas"]["receiver"];
               method: components["schemas"]["payment-method"];
               /** @description The fixed amount that would be sent from the sending wallet address given a successful outgoing payment. */

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -52,6 +52,7 @@ export type JWKS = RSComponents['schemas']['json-web-key-set']
 export type Quote = RSComponents['schemas']['quote']
 type QuoteArgsBase = {
   walletAddress: RSOperations['create-quote']['requestBody']['content']['application/json']['walletAddress']
+  receiverWalletAddress: RSOperations['create-quote']['requestBody']['content']['application/json']['receiverWalletAddress']
   receiver: RSOperations['create-quote']['requestBody']['content']['application/json']['receiver']
   method: RSComponents['schemas']['payment-method']
 }


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Adds `receiverWalletAddress` to `POST /quote` requests.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

Fixes #344.

Because wallet addresses were removed from resource urls, the `receiver` field cannot be used to determine what the receiving wallet address is.