### PR TITLE
fix(openapi): rm first last param defaults

### DIFF
--- a/.changeset/silent-forks-rescue.md
+++ b/.changeset/silent-forks-rescue.md
@@ -1,0 +1,5 @@
+---
+'@interledger/openapi': patch
+---
+
+removes defaults from first and last page parameters

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1284,7 +1284,6 @@ components:
         type: integer
         minimum: 1
         maximum: 100
-        default: 10
       name: first
       in: query
       description: The number of items to return after the cursor.
@@ -1293,7 +1292,6 @@ components:
         type: integer
         minimum: 1
         maximum: 100
-        default: 10
       name: last
       in: query
       description: The number of items to return before the cursor.

--- a/packages/openapi/src/middleware.test.ts
+++ b/packages/openapi/src/middleware.test.ts
@@ -167,8 +167,6 @@ describe('OpenAPI Validator', (): void => {
       ctx.request.query = { 'wallet-address': WALLET_ADDRESS }
       const next = jest.fn().mockImplementation(() => {
         expect(ctx.request.query).toEqual({
-          first: 10,
-          last: 10,
           'wallet-address': WALLET_ADDRESS
         })
         ctx.response.body = {}


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
- removes the defaults which are setting both first and last in the validator middleware, which causes our list lookup to fail because it doesnt expect both
## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
progress towards https://github.com/interledger/rafiki/issues/2116

This works, but I'm actually not sure if this is ultimately the best way and wonder if we might want to tweak it later. It seems like we may have had default parameters in the past without this same issue?