### PR TITLE
feat(open-payments): add authServer to public incoming payment return type

### DIFF
--- a/.changeset/lazy-penguins-roll.md
+++ b/.changeset/lazy-penguins-roll.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Adds authSever to the return type of public incoming payments.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -975,9 +975,16 @@ components:
             value: '0'
             assetCode: USD
             assetScale: 2
+        - authServer: 'https://auth.rafiki.money'
       properties:
         receivedAmount:
           $ref: ./schemas.yaml#/components/schemas/amount
+        authServer:
+          type: string
+          format: uri
+          description: The URL of the authorization server endpoint for getting grants and access tokens for this wallet address.
+      required:
+        - authServer
       unresolvedProperites: false
     outgoing-payment:
       title: Outgoing Payment

--- a/packages/open-payments/src/client/index.ts
+++ b/packages/open-payments/src/client/index.ts
@@ -120,7 +120,7 @@ export interface UnauthenticatedClient {
 }
 
 /**
- * Creates an OpenPayments client that is only able to make requests to get wallet addresses, and wallet address keys.
+ * Creates an OpenPayments client that is only able to make requests for public fields.
  */
 export const createUnauthenticatedClient = async (
   args: CreateUnauthenticatedClientArgs
@@ -153,7 +153,8 @@ export interface CreateAuthenticatedClientArgs
   walletAddressUrl: string
 }
 
-export interface AuthenticatedClient extends UnauthenticatedClient {
+export interface AuthenticatedClient
+  extends Omit<UnauthenticatedClient, 'incomingPayment'> {
   incomingPayment: IncomingPaymentRoutes
   outgoingPayment: OutgoingPaymentRoutes
   grant: GrantRoutes

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -180,6 +180,11 @@ export interface components {
      */
     "public-incoming-payment": {
       receivedAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /**
+       * Format: uri
+       * @description The URL of the authorization server endpoint for getting grants and access tokens for this wallet address.
+       */
+      authServer: string;
     };
     /**
      * Outgoing Payment

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -131,6 +131,7 @@ export const mockPublicIncomingPayment = (
     assetScale: 2,
     value: '0'
   },
+  authServer: 'https://auth.wallet.example/authorize',
   ...overrides
 })
 


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

- adds authSever to the return type of public-incoming-payment in the openapi spec and updates our client accordingly (updated tests, generated type, fixed `AuthenticatedClient` type issue introduced by requiring `authServer`).

## Context

- progress towards https://github.com/interledger/rafiki/issues/2119
