### PR TITLE
fix(open-payments): exports public incoming payment mock, type

### DIFF
--- a/.changeset/chilly-days-repeat.md
+++ b/.changeset/chilly-days-repeat.md
@@ -2,4 +2,4 @@
 '@interledger/open-payments': patch
 ---
 
-exports mockPublicIncomingPayment
+exports mockPublicIncomingPayment and PublicIncomingPayment

--- a/.changeset/chilly-days-repeat.md
+++ b/.changeset/chilly-days-repeat.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': patch
+---
+
+exports mockPublicIncomingPayment

--- a/packages/open-payments/src/index.ts
+++ b/packages/open-payments/src/index.ts
@@ -29,6 +29,7 @@ export {
 export {
   mockWalletAddress,
   mockIncomingPayment,
+  mockPublicIncomingPayment,
   mockIncomingPaymentWithPaymentMethods,
   mockIlpPaymentMethod,
   mockOutgoingPayment,

--- a/packages/open-payments/src/index.ts
+++ b/packages/open-payments/src/index.ts
@@ -2,6 +2,7 @@ export {
   GrantRequest,
   GrantContinuationRequest,
   IncomingPayment,
+  PublicIncomingPayment,
   IncomingPaymentWithPaymentMethods,
   IlpPaymentMethod,
   Quote,


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by merging your branch into integration, and navigating to https://open-payments-integration.readme.io
-->

## Changes proposed in this pull request

- exports public incoming payment mock, type

## Context
while working on the receiver service tests in https://github.com/interledger/rafiki/pull/2122 I discovered these needed to be exported
<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
