### PR TITLE
fix: duplicate link out icon issue

### DIFF
--- a/docs/src/content/docs/snippets/grant-continue.mdx
+++ b/docs/src/content/docs/snippets/grant-continue.mdx
@@ -44,7 +44,7 @@ These code snippets enable an authorized client to issue a grant continuation re
 
 {/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-continuation.ts'>View full sourc</LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-continuation.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/grant-continue.mdx
+++ b/docs/src/content/docs/snippets/grant-continue.mdx
@@ -42,10 +42,9 @@ These code snippets enable an authorized client to issue a grant continuation re
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-continuation.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-continuation.ts'>View full sourc</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/grant-create.mdx
+++ b/docs/src/content/docs/snippets/grant-create.mdx
@@ -55,10 +55,9 @@ When constructing a transaction, the client first requests a grant from the reci
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-incoming-payment.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-incoming-payment.ts'>View full source</LinkOut>
 </p>
 
 ## Request a quote grant
@@ -95,10 +94,9 @@ When constructing a transaction, the client first requests a grant from the reci
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-quote.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-quote.ts'>View full source</LinkOut>
 </p>
 
 ## Request an outgoing payment grant
@@ -135,10 +133,9 @@ When constructing a transaction, the client first requests a grant from the reci
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-outgoing-payment.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-outgoing-payment.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/grant-revoke.mdx
+++ b/docs/src/content/docs/snippets/grant-revoke.mdx
@@ -44,10 +44,9 @@ These code snippets enable a client to revoke (cancel) a grant that it was previ
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-revoke.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-revoke.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/incoming-complete.mdx
+++ b/docs/src/content/docs/snippets/incoming-complete.mdx
@@ -40,10 +40,9 @@ These code snippets pass the wallet address and incoming payment URL to the reso
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-complete.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-complete.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/incoming-create.mdx
+++ b/docs/src/content/docs/snippets/incoming-create.mdx
@@ -40,10 +40,9 @@ These code snippets create an incoming payment of $10 USD at a given wallet addr
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-create.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-create.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/incoming-get.mdx
+++ b/docs/src/content/docs/snippets/incoming-get.mdx
@@ -40,11 +40,11 @@ These code snippets return the state and details of a specific incoming payment,
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-get.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-get.ts'>View full source</LinkOut>
 </p>
+
 ## References
 
 - [API specification](/apis/resource-server/operations/get-incoming-payment)

--- a/docs/src/content/docs/snippets/incoming-list.mdx
+++ b/docs/src/content/docs/snippets/incoming-list.mdx
@@ -40,11 +40,11 @@ These code snippets retrieve the first ten incoming payments on the given wallet
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-list.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/incoming-payment/incoming-payment-list.ts'>View full source</LinkOut>
 </p>
+
 ## References
 
 - [API specification](/apis/resource-server/operations/list-incoming-payments)

--- a/docs/src/content/docs/snippets/outgoing-create.mdx
+++ b/docs/src/content/docs/snippets/outgoing-create.mdx
@@ -43,7 +43,7 @@ These code snippets create an outgoing payment to a given wallet address. The am
 
 {/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-create.ts'>View Full Source</LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-create.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/outgoing-create.mdx
+++ b/docs/src/content/docs/snippets/outgoing-create.mdx
@@ -41,10 +41,9 @@ These code snippets create an outgoing payment to a given wallet address. The am
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-create.ts'>
-    View Full Source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-create.ts'>View Full Source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/outgoing-get.mdx
+++ b/docs/src/content/docs/snippets/outgoing-get.mdx
@@ -40,10 +40,9 @@ These code snippets return the state and details of a specific outgoing payment,
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-get.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-get.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/outgoing-list.mdx
+++ b/docs/src/content/docs/snippets/outgoing-list.mdx
@@ -40,10 +40,9 @@ These code snippets retrieve the first ten outgoing payments on the given wallet
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-list.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/outgoing-payment/outgoing-payment-list.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/quote-create.mdx
+++ b/docs/src/content/docs/snippets/quote-create.mdx
@@ -40,10 +40,9 @@ These code snippets create a quote with a fixed receive amount of $10 USD, meani
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/quote/quote-create.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/quote/quote-create.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/quote-get.mdx
+++ b/docs/src/content/docs/snippets/quote-get.mdx
@@ -42,10 +42,9 @@ These code snippets return the state and details of a specific quote, if found.
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/quote/quote-get.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/quote/quote-get.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/token-revoke.mdx
+++ b/docs/src/content/docs/snippets/token-revoke.mdx
@@ -40,10 +40,9 @@ These code snippets enable the client to call a management endpoint to revoke th
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/token/token-revoke.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/token/token-revoke.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/token-rotate.mdx
+++ b/docs/src/content/docs/snippets/token-rotate.mdx
@@ -42,10 +42,9 @@ These code snippets enable the client to call a management endpoint to rotate th
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/token/token-rotate.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/token/token-rotate.ts'>View full source</LinkOut>
 </p>
 
 ## References

--- a/docs/src/content/docs/snippets/wallet-get-info.mdx
+++ b/docs/src/content/docs/snippets/wallet-get-info.mdx
@@ -39,7 +39,11 @@ These code snippets enable an authenticated client to verify a wallet address, g
 
 </TabItem>
 </Tabs>
-<p><LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/wallet-address/wallet-address-get.ts'>View full source</LinkOut></p>
+
+{/* prettier-ignore */}
+<p>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/wallet-address/wallet-address-get.ts'>View full source</LinkOut>
+</p>
 
 ## References
 

--- a/docs/src/content/docs/snippets/wallet-get-keys.mdx
+++ b/docs/src/content/docs/snippets/wallet-get-keys.mdx
@@ -42,10 +42,9 @@ These code snippets get the keys associated with the specified wallet address.
 </TabItem>
 </Tabs>
 
+{/* prettier-ignore */}
 <p>
-  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/wallet-address/wallet-address-get-keys.ts'>
-    View full source
-  </LinkOut>
+  <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/wallet-address/wallet-address-get-keys.ts'>View full source</LinkOut>
 </p>
 
 ## References


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

This PR fixes the issue where the link out icon appears twice for "View full source" links. This is due to prettier introducing an extra element.

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

N/A
<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
