### PR TITLE
feat: make access_token optional in /continue response in SDK

### DIFF
--- a/.changeset/ninety-beans-do.md
+++ b/.changeset/ninety-beans-do.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Made "access_token" optional for grant continuation responses

--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -189,6 +189,13 @@ paths:
                         value: 33OMUKMKSKU80UPRY5NM
                       uri: 'https://auth.rafiki.money/continue/4CF492MLVMSW9MKMXKHQ'
                       wait: 30
+                Continuing During Pending Interaction:
+                  value:
+                    continue:
+                      access_token:
+                        value: 33OMUKMKSKU80UPRY5NM
+                      uri: 'https://auth.rafiki.money/continue/4CF492MLVMSW9MKMXKHQ'
+                      wait: 30
         '400':
           description: Bad Request
         '401':

--- a/packages/open-payments/src/client/grant.ts
+++ b/packages/open-payments/src/client/grant.ts
@@ -8,6 +8,7 @@ import {
   getASPath,
   PendingGrant,
   Grant,
+  GrantContinuation,
   GrantRequest,
   GrantContinuationRequest
 } from '../types'
@@ -25,7 +26,7 @@ export interface GrantRoutes {
   continue(
     postArgs: GrantOrTokenRequestArgs,
     args: GrantContinuationRequest
-  ): Promise<Grant>
+  ): Promise<Grant | GrantContinuation>
   cancel(postArgs: GrantOrTokenRequestArgs): Promise<void>
 }
 

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -77,6 +77,9 @@ export type Grant = {
   access_token: ASComponents['schemas']['access_token']
   continue: ASComponents['schemas']['continue']
 }
+export type GrantContinuation = {
+  continue: ASComponents['schemas']['continue']
+}
 export type GrantRequest = {
   access_token: ASOperations['post-request']['requestBody']['content']['application/json']['access_token']
   client: ASOperations['post-request']['requestBody']['content']['application/json']['client']

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -99,6 +99,10 @@ export const isPendingGrant = (
   grant: PendingGrant | Grant
 ): grant is PendingGrant => !!(grant as PendingGrant).interact
 
+export const isFinalizedGrant = (
+  grant: GrantContinuation | Grant
+): grant is Grant => !!(grant as Grant).access_token
+
 export type AccessIncomingActions =
   ASComponents['schemas']['access-incoming']['actions']
 export type AccessOutgoingActions =


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Makes the `access_token` field optional for `POST /continue/{id}` on the authorization server Open Payments SDK.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

Fixes #385 

Allows the continue endpoint for an authorization server to be polled for interaction completion.