### PR TITLE
fix: export grant continuation

### DIFF
--- a/packages/open-payments/src/index.ts
+++ b/packages/open-payments/src/index.ts
@@ -1,5 +1,6 @@
 export {
   GrantRequest,
+  GrantContinuation,
   GrantContinuationRequest,
   IncomingPayment,
   PublicIncomingPayment,


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Exports `GrantContinuation` and `isFinalizedGrant` from the package

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

Forgot to export those two items from the package in https://github.com/interledger/open-payments/pull/386