### PR TITLE
fix: pull in correct openapi spec for wallet address routes in sdk

### DIFF
--- a/.changeset/modern-cups-develop.md
+++ b/.changeset/modern-cups-develop.md
@@ -1,0 +1,6 @@
+---
+'@interledger/open-payments': minor
+---
+
+- Pulls in correct OpenAPI spec when wallet address validators are created in the SDK.
+- Updates the types returned by Grant continue route.

--- a/packages/open-payments/src/client/grant.ts
+++ b/packages/open-payments/src/client/grant.ts
@@ -39,7 +39,9 @@ export const createGrantRoutes = (deps: GrantRouteDeps): GrantRoutes => {
     path: getASPath('/'),
     method: HttpMethod.POST
   })
-  const continueGrantValidator = openApi.createResponseValidator<Grant>({
+  const continueGrantValidator = openApi.createResponseValidator<
+    GrantContinuation | Grant
+  >({
     path: getASPath('/continue/{id}'),
     method: HttpMethod.POST
   })

--- a/packages/open-payments/src/client/index.ts
+++ b/packages/open-payments/src/client/index.ts
@@ -224,13 +224,13 @@ export interface UnauthenticatedClient {
 export const createUnauthenticatedClient = async (
   args: CreateUnauthenticatedClientArgs
 ): Promise<UnauthenticatedClient> => {
-  const { resourceServerOpenApi, ...baseDeps } =
+  const { resourceServerOpenApi, walletAddressServerOpenApi, ...baseDeps } =
     await createUnauthenticatedDeps(args)
 
   return {
     walletAddress: createWalletAddressRoutes({
       ...baseDeps,
-      openApi: resourceServerOpenApi
+      openApi: walletAddressServerOpenApi
     }),
     incomingPayment: createUnauthenticatedIncomingPaymentRoutes({
       ...baseDeps,


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Updates the wallet address route validators to pull from the wallet address spec instead of the resource server spec.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
Fixes #396.
When `@interledger/open-payments` at 6.2.0 and onward gets imported, it fails to create the route validators for wallet addresses. The reason for this is that the routes for wallet addresses were moved from the resource server spec, which the validators were still trying to pull from, to a separate wallet address server spec. So the routes were no longer being found when seeking them in the resource server spec.
