### PR TITLE
Update create-interactive-grant.mdx

### DIFF
--- a/docs/src/content/docs/guides/create-interactive-grant.mdx
+++ b/docs/src/content/docs/guides/create-interactive-grant.mdx
@@ -60,12 +60,12 @@ HTTP Message Signatures protect the integrity of Open Payments API requests. The
 Indicate your client is capable of directing the end-user to a URI to start an interaction. We’ll use an outgoing payment grant as an example.
 
 1. Add the `interact` object to your grant request.
-2. Specify `redirect` as the `start` mode. Open Payments only supports `redirect`. The redirect URI will be provided by the authorization server in its response.
+2. Specify `redirect` as the `start` mode. Open Payments only supports `redirect` at this time. The redirect URI will be provided by the authorization server in its response.
 
 Now, indicate your client can receive a signal from the authorization server when the interaction has finished.
 
 1. Add the `finish` object within the `interact` object.
-2. Specify `redirect` as the `method`. Open Payments only supports `redirect`.
+2. Specify `redirect` as the `method`. Open Payments only supports `redirect` at this time.
 3. Specify the `uri` that the authorization server will send the end-user back to when the interaction has finished.
 4. Create a `nonce` for your client to use to verify the authorization server is the same entity throughout the entire process. The nonce can be any random, hard-to-guess string.
 
@@ -81,10 +81,28 @@ Now, indicate your client can receive a signal from the authorization server whe
 
 #### Start interaction with the end user
 
-Once your client receives the authorization server’s response, it must send the end-user to the `interact redirect` URI contained in the response. This starts the interaction flow.
+Once your client receives the authorization server’s response, it must send the end-user to the `interact.redirect` URI contained in the response. This starts the interaction flow.
+
+<CodeBlock title="Example response">
+```json
+{
+  "interact": {
+    "redirect": "https://auth.rafiki.money/4CF492MLVMSW9MKMXKHQ",
+    "finish": "4105340a-05eb-4290-8739-f9e2b463bfa7"
+  },
+  "continue": {
+    "access_token": {
+      "value": "33OMUKMKSKU80UPRY5NM"
+    },
+    "uri": "https://auth.rafiki.money/continue/4CF492MLVMSW9MKMXKHQ",
+    "wait": 30
+  }
+}
+```
+</CodeBlock>
 
 :::note
-Open Payments only supports the `redirect` method. The means by which your client activates the URI is out of scope, but common redirect methods include HTTP redirect and launching a browser on the end-user’s device.
+Open Payments only supports the `redirect` method at this time. The means by which your client activates the URI is out of scope, but common redirect methods include HTTP redirect and launching a browser on the end-user’s device.
 :::
 
 #### Finish interaction with the end user
@@ -107,9 +125,50 @@ Add the authorization server’s interaction reference, as the `interact_ref` va
 
 Issue the request to the `continue uri` supplied in the authorization server’s initial grant response. For example:
 
-`POST https://auth.rafiki.money/continue/49fb4a97-f880-449c-b0e9-d3ac1c947b10`
+`POST https://auth.rafiki.money/continue/4CF492MLVMSW9MKMXKHQ`
 
 A successful continuation response from the authorization server provides your client with an access token and other information necessary to continue the transaction.
+
+<CodeBlock title="Example response">
+```json
+{
+  "access_token": {
+    "value": "OS9M2PMHKUR64TB8N6BW7OZB8CDFONP219RP1LT0",
+    "manage": "https://auth.rafiki.money/token/dd17a202-9982-4ed9-ae31-564947fb6379",
+    "expires_in": 3600,
+    "access": [
+      {
+        "type": "outgoing-payment",
+        "actions": [
+          "create",
+          "read",
+          "read-all",
+          "list",
+          "list-all"
+        ],
+        "identifier": "https://ilp.rafiki.money/alice",
+        "limits": {
+          "receiver": "https://ilp.rafiki.money/bob/incoming-payments/48884225-b393-4872-90de-1b737e2491c2",
+          "interval": "R12/2019-08-24T14:15:22Z/P1M",
+          "debitAmount": {
+            "value": "500",
+            "assetCode": "USD",
+            "assetScale": 2
+          }
+        }
+      }
+    ]
+  },
+  "continue": {
+    "access_token": {
+      "value": "33OMUKMKSKU80UPRY5NM"
+    },
+    "uri": "https://auth.rafiki.money/continue/4CF492MLVMSW9MKMXKHQ",
+    "wait": 30
+  }
+}
+```
+</CodeBlock>
 
 </TabItem>
 </Tabs>

--- a/docs/src/content/docs/guides/create-interactive-grant.mdx
+++ b/docs/src/content/docs/guides/create-interactive-grant.mdx
@@ -3,26 +3,27 @@ title: Create an interactive grant
 ---
 
 import { CodeBlock, LinkOut } from '@interledger/docs-design-system'
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+import ChunkedSnippet from '/src/components/ChunkedSnippet.astro'
+import Ts from '/src/partials/ts-prerequisites.mdx'
 
-This guide describes how to create an interactive grant. An interactive grant is a type of grant that requires interaction from a user, typically your client’s end-user, before the grant can be issued.
+This guide describes how to create an interactive grant. An interactive grant requires interaction from a user, typically your client’s end-user, before the grant can be issued.
 
-Open Payments requires an interactive grant before your client can issue a request to create an outgoing payment. This is because the outgoing payment account holder (typically your client’s end-user) must explicitly consent to the creation of the outgoing payment.
+For outgoing payment grants, the resource owner (e.g., your client's end-user) must explicitly consent to the creation of an outgoing payment resource. As such, Open Payments requires outgoing payment grants be interactive.
 
-Although grants for creating incoming payments and quotes are non-interactive by default, you can choose to make one or both interactive to fit your implementation needs.
+Grants for creating incoming payment and quote resources are non-interactive by default; however, you can choose to make one or both interactive to fit your implementation needs.
 
-### Prerequisites
-
-- Node 18
-- TypeScript
-- NPM
-
-### Dependencies
+## Dependencies
 
 - <LinkOut href='https://github.com/interledger/open-payments/tree/main/packages/open-payments'>
     Open Payments SDK
   </LinkOut>
 
-### Endpoints
+:::note[HTTP Message Signatures]
+HTTP Message Signatures protect the integrity of Open Payments API requests. The Open Payments SDK includes the <LinkOut href='https://github.com/interledger/open-payments/tree/main/packages/http-signature-utils'>HTTP Signature Utils library</LinkOut>, which provides tools for working with HTTP Message Signatures. Additional information can be found in the [Client keys](/introduction/client-keys) and [HTTP message signatures](/introduction/http-signatures) pages.
+:::
+
+## Endpoints
 
 - <LinkOut href='https://openpayments.guide/apis/auth-server/operations/post-request/'>
     Grant Request
@@ -31,56 +32,62 @@ Although grants for creating incoming payments and quotes are non-interactive by
     Continuation Request
   </LinkOut>
 
-## Steps
+## Create an interactive grant
 
-### 1. Specify a redirect start mode
+<Tabs>
+<TabItem label='TypeScript'>
+<Ts />
 
-Indicate your client is capable of directing the end-user to a URI to start an interaction.
+#### Get started
 
-1. Add the `interact` object to your [grant request](/apis/auth-server/operations/post-request/#request-body).
-2. Specify `redirect` as the `start` mode. Open Payments only supports `redirect`.
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-outgoing-payment.ts'
+  chunk='1'
+/>
 
-The URI will be provided by the authorization server in its response.
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-outgoing-payment.ts'
+  chunk='2'
+/>
 
-```ts
-interact: {
-    start: ["redirect"],
-},
-```
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-outgoing-payment.ts'
+  chunk='3'
+/>
 
-### 2. Specify a redirect finish mode
+#### Request an interactive grant
 
-Indicate your client can receive a signal from the authorization server when the interaction has finished.
+Indicate your client is capable of directing the end-user to a URI to start an interaction. We’ll use an outgoing payment grant as an example.
 
-1. Add the `finish` object within the existing `interact` object.
+1. Add the `interact` object to your grant request.
+2. Specify `redirect` as the `start` mode. Open Payments only supports `redirect`. The redirect URI will be provided by the authorization server in its response.
+
+Now, indicate your client can receive a signal from the authorization server when the interaction has finished.
+
+1. Add the `finish` object within the `interact` object.
 2. Specify `redirect` as the `method`. Open Payments only supports `redirect`.
 3. Specify the `uri` that the authorization server will send the end-user back to when the interaction has finished.
 4. Create a `nonce` for your client to use to verify the authorization server is the same entity throughout the entire process. The nonce can be any random, hard-to-guess string.
 
-<CodeBlock title="Example">
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-outgoing-payment.ts'
+  chunk='4'
+/>
 
-```ts
-interact: {
-    start: ["redirect"],
-    finish: {
-        method: "redirect",
-        uri: "https://example.wallet.com/return/876FGRD8VC",
-        nonce: 4edb2194-dbdf-46bb-9397-d5fd57b7c8a7,
-    },
-},
-```
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-outgoing-payment.ts'
+  chunk='5'
+/>
 
-</CodeBlock>
+#### Start interaction with the end user
 
-### 3. Interact with the end user
+Once your client receives the authorization server’s response, it must send the end-user to the `interact redirect` URI contained in the response. This starts the interaction flow.
 
-#### Start interaction
-
-Once your client receives the [authorization server’s response](/apis/auth-server/operations/post-request/#responses), it must send the end-user to the `interact redirect` URI contained in the response. This initiates the interaction flow.
-
+:::note
 Open Payments only supports the `redirect` method. The means by which your client activates the URI is out of scope, but common redirect methods include HTTP redirect and launching a browser on the end-user’s device.
+:::
 
-#### Finish interaction
+#### Finish interaction with the end user
 
 The end-user interacts with the authorization server through the server’s interface and approves or denies the grant.
 
@@ -89,22 +96,20 @@ Provided the end-user approves the grant, the authorization server:
 - Sends the end-user to your client’s previously defined `finish uri`. The means by which the server sends the end-user to the URI is out of scope, but common options include redirecting the end-user from a web page and launching the system browser with the target URI.
 - Secures the redirect by adding a unique hash, allowing your client to validate the `finish` call, and an interaction reference as query parameters to the URI.
 
-### 4. Request a grant continuation
+#### Request a grant continuation
 
-Add the authorization server’s interaction reference, as the `interact_ref` value, to the body of your [continuation request](/apis/auth-server/operations/post-continue/#request-body).
+Add the authorization server’s interaction reference, as the `interact_ref` value, to the body of your continuation request.
 
-<CodeBlock title="Example">
-
-```ts
-{
-    interact_ref: ad82597c-bbfa-4eb0-b72e-328e005b8689,
-},
-```
-
-</CodeBlock>
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-continuation.ts'
+  chunk='3'
+/>
 
 Issue the request to the `continue uri` supplied in the authorization server’s initial grant response. For example:
 
 `POST https://auth.rafiki.money/continue/49fb4a97-f880-449c-b0e9-d3ac1c947b10`
 
-A successful [continuation response](/apis/auth-server/operations/post-continue/#responses) from the authorization server provides your client with an access token and other information necessary to continue the transaction.
+A successful continuation response from the authorization server provides your client with an access token and other information necessary to continue the transaction.
+
+</TabItem>
+</Tabs>

--- a/docs/src/content/docs/guides/create-interactive-grant.mdx
+++ b/docs/src/content/docs/guides/create-interactive-grant.mdx
@@ -93,7 +93,7 @@ The end-user interacts with the authorization server through the server’s inte
 
 Provided the end-user approves the grant, the authorization server:
 
-- Sends the end-user to your client’s previously defined `finish uri`. The means by which the server sends the end-user to the URI is out of scope, but common options include redirecting the end-user from a web page and launching the system browser with the target URI.
+- Sends the end-user to your client’s previously defined `finish.uri`. The means by which the server sends the end-user to the URI is out of scope, but common options include redirecting the end-user from a web page and launching the system browser with the target URI.
 - Secures the redirect by adding a unique hash, allowing your client to validate the `finish` call, and an interaction reference as query parameters to the URI.
 
 #### Request a grant continuation

--- a/docs/src/styles/openpayments.css
+++ b/docs/src/styles/openpayments.css
@@ -13,6 +13,11 @@
   max-width: 48rem;
 }
 
+/* Odd one-off margin issue with expressive code (will hoist if seen again) */
+div.expressive-code figure.frame {
+  margin-top: 0;
+}
+
 /* OpenAPI specification styling */
 div.panel {
   background-color: var(--sl-color-gray-7);


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

Initial revisions to the "Create Interactive Grant" guide for review and feedback.

## Context

After reviewing the first draft of the guides, we decided that they need to:
* Display the code snippets (as applicable) instead of API bodies
* Use a tabbed display for languages, like the Code Snippets pages
* Contain explanations for any applicable API properties so that our audience won't need to toggle between the API docs and the guides
* Mention, in some fashion, information about signature headers