### PR TITLE
feat(op): add monetization client

### DIFF
--- a/packages/open-payments/src/client/requests.ts
+++ b/packages/open-payments/src/client/requests.ts
@@ -176,7 +176,12 @@ interface CreateMonetizationAxiosInstanceArgs extends BaseAxiosInstanceArgs {
   requestInterceptor: InterceptorFn
 }
 
+type CreateAxiosInstanceArgs =
+  | CreateBaseAxiosInstanceArgs
+  | CreateMonetizationAxiosInstanceArgs
+
 const isMonetizationArgs = (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   args: any
 ): args is CreateMonetizationAxiosInstanceArgs => {
   return typeof args.requestInterceptor === 'function'
@@ -189,7 +194,7 @@ export function createAxiosInstance(
   args: CreateMonetizationAxiosInstanceArgs
 ): AxiosInstance
 export function createAxiosInstance(
-  args: any
+  args: CreateAxiosInstanceArgs
 ): AxiosInstance {
   const axiosInstance = axios.create({
     headers: {

--- a/packages/open-payments/src/index.ts
+++ b/packages/open-payments/src/index.ts
@@ -25,6 +25,7 @@ export {
 export {
   createAuthenticatedClient,
   createUnauthenticatedClient,
+  createMonetizationClient,
   AuthenticatedClient,
   UnauthenticatedClient,
   OpenPaymentsClientError


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request
At the moment, the SDK cannot be used in a browser environment. This is a PoC on how the SDK can work in a browser environment without providing the `privateKey` and `keyId` pair. 

It adds a monetization client, which accepts a custom request interceptor. For the WM Extension, at the moment, a Cloud Function is used to generate the HTTP signatures, since we should not include the private key and the key ID in the extension's bundle.



<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
- Potential to fix #412