### PR TITLE
feat(sig-utils): upgrade `http-message-signatures` to the most recent version

### DIFF
--- a/.changeset/light-rabbits-rhyme.md
+++ b/.changeset/light-rabbits-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@interledger/http-signature-utils': patch
+---
+
+Upgrade the `http-message-signatures` package to the most recent version.

--- a/packages/http-signature-utils/package.json
+++ b/packages/http-signature-utils/package.json
@@ -24,7 +24,7 @@
     "prepack": "pnpm build"
   },
   "dependencies": {
-    "http-message-signatures": "^0.1.2",
+    "http-message-signatures": "^1.0.4",
     "httpbis-digest-headers": "^1.0.0",
     "jose": "^4.13.1",
     "uuid": "^9.0.0"

--- a/packages/http-signature-utils/src/index.ts
+++ b/packages/http-signature-utils/src/index.ts
@@ -6,7 +6,6 @@ export {
   loadOrGenerateKey,
   loadBase64Key
 } from './utils/key'
-export { createSignatureHeaders } from './utils/signatures'
+export { createSignatureHeaders, type RequestLike } from './utils/signatures'
 export { validateSignatureHeaders, validateSignature } from './utils/validation'
 export { generateTestKeys, TestKeys } from './test-utils/keys'
-export { RequestLike } from 'http-message-signatures'

--- a/packages/http-signature-utils/src/utils/signatures.test.ts
+++ b/packages/http-signature-utils/src/utils/signatures.test.ts
@@ -1,6 +1,5 @@
 import { generateTestKeys, TestKeys } from '../test-utils/keys'
 import { createSignatureHeaders, RequestLike } from './signatures'
-import { httpbis } from 'http-message-signatures'
 
 describe('Signature Generation', (): void => {
   let testKeys: TestKeys

--- a/packages/http-signature-utils/src/utils/signatures.test.ts
+++ b/packages/http-signature-utils/src/utils/signatures.test.ts
@@ -29,7 +29,6 @@ describe('Signature Generation', (): void => {
         return key
       })
 
-    expect(signatureParameters).toContain('alg')
     expect(signatureParameters).toContain('keyid')
     expect(signatureParameters).toContain('created')
   })

--- a/packages/http-signature-utils/src/utils/signatures.test.ts
+++ b/packages/http-signature-utils/src/utils/signatures.test.ts
@@ -1,0 +1,37 @@
+import { generateTestKeys, TestKeys } from '../test-utils/keys'
+import { createSignatureHeaders, RequestLike } from './signatures'
+import { httpbis } from 'http-message-signatures'
+
+describe('Signature Generation', (): void => {
+  let testKeys: TestKeys
+
+  beforeEach((): void => {
+    testKeys = generateTestKeys()
+  })
+
+  test('ensure that the signature input header contains the correct parameters', async (): Promise<void> => {
+    const request: RequestLike = {
+      headers: {},
+      method: 'GET',
+      url: 'http://example.com/test'
+    }
+
+    const signatureHeaders = await createSignatureHeaders({
+      request,
+      privateKey: testKeys.privateKey,
+      keyId: testKeys.publicKey.kid
+    })
+
+    const signatureParameters = signatureHeaders['Signature-Input']
+      .split(';')
+      .splice(1, 3)
+      .map((param) => {
+        const [key] = param.split('=')
+        return key
+      })
+
+    expect(signatureParameters).toContain('alg')
+    expect(signatureParameters).toContain('keyid')
+    expect(signatureParameters).toContain('created')
+  })
+})

--- a/packages/http-signature-utils/src/utils/signatures.ts
+++ b/packages/http-signature-utils/src/utils/signatures.ts
@@ -38,7 +38,11 @@ export const createSignatureHeaders = async ({
       params: ['alg', 'keyid', 'created'],
       fields: components
     },
-    request
+    {
+      method: request.method,
+      url: request.url,
+      headers: request.headers
+    }
   )
 
   return {

--- a/packages/http-signature-utils/src/utils/signatures.ts
+++ b/packages/http-signature-utils/src/utils/signatures.ts
@@ -35,7 +35,7 @@ export const createSignatureHeaders = async ({
     {
       key: signingKey,
       name: 'sig1',
-      params: ['alg', 'keyid', 'created'],
+      params: ['keyid', 'created'],
       fields: components
     },
     {

--- a/packages/http-signature-utils/src/utils/signatures.ts
+++ b/packages/http-signature-utils/src/utils/signatures.ts
@@ -1,10 +1,9 @@
-import { sign, KeyLike, BinaryLike } from 'crypto'
-import {
-  httpis as httpsig,
-  Algorithm,
-  RequestLike,
-  Signer
-} from 'http-message-signatures'
+import { type KeyLike } from 'crypto'
+import { httpbis, createSigner, Request } from 'http-message-signatures'
+
+export interface RequestLike extends Request {
+  body?: string
+}
 
 export interface SignOptions {
   request: RequestLike
@@ -15,13 +14,6 @@ export interface SignOptions {
 export interface SignatureHeaders {
   Signature: string
   'Signature-Input': string
-}
-
-const createSigner = (privateKey: KeyLike): Signer => {
-  const signer = async (data: BinaryLike) =>
-    sign(null, data as Buffer, privateKey)
-  signer.alg = 'ed25519' as Algorithm
-  return signer
 }
 
 export const createSignatureHeaders = async ({
@@ -36,15 +28,19 @@ export const createSignatureHeaders = async ({
   if (request.body) {
     components.push('content-digest', 'content-length', 'content-type')
   }
-  const { headers } = await httpsig.sign(request, {
-    components,
-    parameters: {
-      created: Math.floor(Date.now() / 1000)
+
+  const signingKey = createSigner(privateKey, 'ed25519', keyId)
+
+  const { headers } = await httpbis.signMessage(
+    {
+      key: signingKey,
+      name: 'sig1',
+      params: ['alg', 'keyid', 'created'],
+      fields: components
     },
-    keyId,
-    signer: createSigner(privateKey),
-    format: 'httpbis'
-  })
+    request
+  )
+
   return {
     Signature: headers['Signature'] as string,
     'Signature-Input': headers['Signature-Input'] as string

--- a/packages/http-signature-utils/src/utils/validation.test.ts
+++ b/packages/http-signature-utils/src/utils/validation.test.ts
@@ -1,6 +1,6 @@
 import { validateSignatureHeaders, validateSignature } from './validation'
 import { createHeaders } from './headers'
-import { RequestLike } from 'http-message-signatures'
+import { RequestLike } from './signatures'
 import { TestKeys, generateTestKeys } from '../test-utils/keys'
 import { createContentDigestHeader } from 'httpbis-digest-headers'
 

--- a/packages/http-signature-utils/src/utils/validation.ts
+++ b/packages/http-signature-utils/src/utils/validation.ts
@@ -1,5 +1,5 @@
 import * as crypto from 'crypto'
-import { RequestLike } from 'http-message-signatures'
+import { RequestLike } from './signatures'
 import { verifyContentDigest } from 'httpbis-digest-headers'
 import { importJWK } from 'jose'
 import { JWK } from './jwk'

--- a/packages/open-payments/src/client/requests.test.ts
+++ b/packages/open-payments/src/client/requests.test.ts
@@ -71,9 +71,9 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "authorization");created=${Math.floor(
+          `sig1=("@method" "@target-uri" "authorization");alg="ed25519";keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
-          )};keyid="${keyId}";alg="ed25519"`
+          )}`
         )
         .get('/incoming-payments')
         // TODO: verify signature
@@ -295,9 +295,9 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "content-digest" "content-length" "content-type");created=${Math.floor(
+          `sig1=("@method" "@target-uri" "content-digest" "content-length" "content-type");alg="ed25519";keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
-          )};keyid="${keyId}";alg="ed25519"`
+          )}`
         )
         .matchHeader('Accept', 'application/json')
         .matchHeader('Content-Digest', /sha-512=:([a-zA-Z0-9+/]){86}==:/)
@@ -350,9 +350,9 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "authorization" "content-digest" "content-length" "content-type");created=${Math.floor(
+          `sig1=("@method" "@target-uri" "authorization" "content-digest" "content-length" "content-type");alg="ed25519";keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
-          )};keyid="${keyId}";alg="ed25519"`
+          )}`
         )
         .matchHeader('Accept', 'application/json')
         .matchHeader('Authorization', `GNAP ${accessToken}`)
@@ -531,9 +531,9 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "authorization");created=${Math.floor(
+          `sig1=("@method" "@target-uri" "authorization");alg="ed25519";keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
-          )};keyid="${keyId}";alg="ed25519"`
+          )}`
         )
         .matchHeader('Authorization', `GNAP ${accessToken}`)
         .delete(`/grant/`)

--- a/packages/open-payments/src/client/requests.test.ts
+++ b/packages/open-payments/src/client/requests.test.ts
@@ -71,7 +71,7 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "authorization");alg="ed25519";keyid="${keyId}";created=${Math.floor(
+          `sig1=("@method" "@target-uri" "authorization");keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
           )}`
         )
@@ -295,7 +295,7 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "content-digest" "content-length" "content-type");alg="ed25519";keyid="${keyId}";created=${Math.floor(
+          `sig1=("@method" "@target-uri" "content-digest" "content-length" "content-type");keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
           )}`
         )
@@ -350,7 +350,7 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "authorization" "content-digest" "content-length" "content-type");alg="ed25519";keyid="${keyId}";created=${Math.floor(
+          `sig1=("@method" "@target-uri" "authorization" "content-digest" "content-length" "content-type");keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
           )}`
         )
@@ -531,7 +531,7 @@ describe('requests', (): void => {
         .matchHeader('Signature', /sig1=:([a-zA-Z0-9+/]){86}==:/)
         .matchHeader(
           'Signature-Input',
-          `sig1=("@method" "@target-uri" "authorization");alg="ed25519";keyid="${keyId}";created=${Math.floor(
+          `sig1=("@method" "@target-uri" "authorization");keyid="${keyId}";created=${Math.floor(
             Date.now() / 1000
           )}`
         )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
   packages/http-signature-utils:
     dependencies:
       http-message-signatures:
-        specifier: ^0.1.2
-        version: 0.1.2
+        specifier: ^1.0.4
+        version: 1.0.4
       httpbis-digest-headers:
         specifier: ^1.0.0
         version: 1.0.0
@@ -5451,6 +5451,12 @@ packages:
     resolution: {integrity: sha512-gjJYDgFBy+xnlAs2G0gIWpiorCv9Xi7pIlOnnd91zHAK7BtkLxonmm/JAtd5e6CakOuW03IwEuJzj2YMy8lfWQ==}
     dev: false
 
+  /http-message-signatures@1.0.4:
+    resolution: {integrity: sha512-gavCQWnxHFg0BVlKs6CmYK7hNSH1o0x0mHTC68yBAHYOYuTVXPv52mEE7QuT5TenfiagTdOa/zPJzen4lEX7Rg==}
+    dependencies:
+      structured-headers: 1.0.1
+    dev: false
+
   /httpbis-digest-headers@1.0.0:
     resolution: {integrity: sha512-RpaFuZD3tG8wtsvjDv1u7O8wAvfpAxS20F3CrFPZOMn+IBb7E7yiqlN5Tks4E5tBEnTdpMOD151rJsUv03sAIg==}
     dependencies:
@@ -8918,6 +8924,11 @@ packages:
 
   /structured-headers@0.5.0:
     resolution: {integrity: sha512-oLnmXSsjhud+LxRJpvokwP8ImEB2wTg8sg30buwfVViKMuluTv3BlOJHUX9VW9pJ2nQOxmx87Z0kB86O4cphag==}
+    dev: false
+
+  /structured-headers@1.0.1:
+    resolution: {integrity: sha512-QYBxdBtA4Tl5rFPuqmbmdrS9kbtren74RTJTcs0VSQNVV5iRhJD4QlYTLD0+81SBwUQctjEQzjTRI3WG4DzICA==}
+    engines: {node: '>= 14', npm: '>=6'}
     dev: false
 
   /style-to-object@0.4.2:


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request
Update `http-message-signatures` to its latest version and fix breaking changes.

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
Closes #420.