### PR TITLE
chore: update wallet address links

### DIFF
--- a/docs/src/content/docs/guides/make-onetime-payment.mdx
+++ b/docs/src/content/docs/guides/make-onetime-payment.mdx
@@ -25,7 +25,7 @@ Examples of use cases for a one-time payment might be an e-commerce or a money t
 - <LinkOut href='https://openpayments.guide/apis/auth-server/operations/post-request/'>
     Grant Request
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/get-wallet-address/'>
+- <LinkOut href='https://openpayments.guide/apis/wallet-address-server/operations/get-wallet-address/'>
     Get a Wallet address
   </LinkOut>
 - <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-incoming-payment/'>

--- a/docs/src/content/docs/guides/make-recurring-payments.mdx
+++ b/docs/src/content/docs/guides/make-recurring-payments.mdx
@@ -26,7 +26,7 @@ An example use case for making recurring payments may be a Buy Now Pay Later (BN
 - <LinkOut href='https://openpayments.guide/apis/auth-server/operations/post-request/'>
     Grant Request
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/get-wallet-address/'>
+- <LinkOut href='https://openpayments.guide/apis/wallet-address-server/operations/get-wallet-address/'>
     Get a Wallet address
   </LinkOut>
 - <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-incoming-payment/'>

--- a/docs/src/content/docs/snippets/wallet-get-info.mdx
+++ b/docs/src/content/docs/snippets/wallet-get-info.mdx
@@ -56,5 +56,5 @@ Run `tsx path/to/directory/index.ts`.
 
 ## References
 
-- [API specification](/apis/resource-server/operations/get-wallet-address)
+- [API specification](/apis/wallet-address-server/operations/get-wallet-address)
 - [Wallet addresses](/introduction/wallet-addresses)

--- a/docs/src/content/docs/snippets/wallet-get-keys.mdx
+++ b/docs/src/content/docs/snippets/wallet-get-keys.mdx
@@ -58,5 +58,5 @@ Run `tsx path/to/directory/index.ts`.
 
 ## References
 
-- [API specification](/apis/resource-server/operations/get-wallet-address-keys)
+- [API specification](/apis/wallet-address-server/operations/get-wallet-address-keys)
 - [Wallet addresses](/introduction/wallet-addresses)


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request
Update wallet address links to point to the wallet address server (instead of the old resource server)

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
