### PR TITLE
feat: update receiver regex validation

### DIFF
--- a/.changeset/fuzzy-rivers-jog.md
+++ b/.changeset/fuzzy-rivers-jog.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Widened receiver regex to accept http and any id format. Removed previously deprecated 'connections' path.

--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -110,7 +110,7 @@ paths:
                           - read
                         identifier: 'https://ilp.rafiki.money/alice'
                         limits:
-                          receiver: 'https://ilp.rafiki.money/connections/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
+                          receiver: 'https://ilp.rafiki.money/incoming-payment/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                           interval: 'R12/2019-08-24T14:15:22Z/P1M'
                           debitAmount:
                             value: '500'

--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -110,7 +110,7 @@ paths:
                           - read
                         identifier: 'https://ilp.rafiki.money/alice'
                         limits:
-                          receiver: 'https://ilp.rafiki.money/incoming-payment/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
+                          receiver: 'https://ilp.rafiki.money/incoming-payments/45a0d0ee-26dc-4c66-89e0-01fbf93156f7'
                           interval: 'R12/2019-08-24T14:15:22Z/P1M'
                           debitAmount:
                             value: '500'

--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -40,7 +40,7 @@ components:
     receiver:
       title: Receiver
       type: string
-      description: The URL of the incoming payment or ILP STREAM connection that is being paid.
+      description: The URL of the incoming payment that is being paid.
       format: uri
       pattern: '^(https|http)://(.+)/incoming-payments/(.+)$'
       examples:

--- a/openapi/schemas.yaml
+++ b/openapi/schemas.yaml
@@ -42,10 +42,11 @@ components:
       type: string
       description: The URL of the incoming payment or ILP STREAM connection that is being paid.
       format: uri
-      pattern: '^https://(.+)/(incoming-payments|connections)/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$'
+      pattern: '^(https|http)://(.+)/incoming-payments/(.+)$'
       examples:
         - 'https://ilp.rafiki.money/incoming-payments/08394f02-7b7b-45e2-b645-51d04e7c330c'
-        - 'https://ilp.rafiki.money/connections/016da9d5-c9a4-4c80-a354-86b915a04ff8'
+        - 'http://ilp.rafiki.money/incoming-payments/08394f02-7b7b-45e2-b645-51d04e7c330c'
+        - 'https://ilp.rafiki.money/incoming-payments/1'
     walletAddress:
       title: Wallet Address
       type: string

--- a/packages/open-payments/src/openapi/generated/auth-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/auth-server-types.ts
@@ -337,7 +337,7 @@ export interface external {
         /**
          * Receiver
          * Format: uri
-         * @description The URL of the incoming payment or ILP STREAM connection that is being paid.
+         * @description The URL of the incoming payment that is being paid.
          */
         receiver: string;
         /**

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -629,7 +629,7 @@ export interface external {
         /**
          * Receiver
          * Format: uri
-         * @description The URL of the incoming payment or ILP STREAM connection that is being paid.
+         * @description The URL of the incoming payment that is being paid.
          */
         receiver: string;
         /**

--- a/packages/open-payments/src/openapi/generated/wallet-address-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/wallet-address-server-types.ts
@@ -156,7 +156,7 @@ export interface external {
         /**
          * Receiver
          * Format: uri
-         * @description The URL of the incoming payment or ILP STREAM connection that is being paid.
+         * @description The URL of the incoming payment that is being paid.
          */
         receiver: string;
         /**


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

changes the receiver regex so that:
  -  it now matches with `http` and any id (instead of just uuid)
  -  it does not match with deprecated `/connections/` path

## Context

I noticed when using the client in the local environment that a receiver with an `http` url fails validation, which is necessary for local development. We are already using such a url, we're just not using the client for it (see the bruno/postman `Create Quote` request body). Widening that was the main goal and the other changes are more cleanup.

fixes https://github.com/interledger/open-payments/issues/429