### PR TITLE
feat: make body, interact_ref optional on client grant continue

### DIFF
--- a/.changeset/olive-eagles-talk.md
+++ b/.changeset/olive-eagles-talk.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': patch
+---
+
+Makes body and interact_ref optional on continuation route

--- a/packages/open-payments/src/client/grant.test.ts
+++ b/packages/open-payments/src/client/grant.test.ts
@@ -83,30 +83,68 @@ describe('grant', (): void => {
     })
 
     describe('continue', () => {
-      test('calls post method with correct validator', async (): Promise<void> => {
+      describe('calls post method with correct validator', (): void => {
         const mockResponseValidator = ({ path, method }) =>
           path === '/continue/{id}' && method === HttpMethod.POST
 
-        jest
-          .spyOn(openApi, 'createResponseValidator')
-          .mockImplementation(mockResponseValidator as any)
+        test('with interact_ref', async (): Promise<void> => {
+          jest
+            .spyOn(openApi, 'createResponseValidator')
+            .mockImplementation(mockResponseValidator as any)
 
-        const postSpy = jest.spyOn(requestors, 'post')
-        const interact_ref = uuid()
+          const postSpy = jest.spyOn(requestors, 'post')
+          const interact_ref = uuid()
 
-        await createGrantRoutes({ openApi, client, ...deps }).continue(
-          {
+          await createGrantRoutes({ openApi, client, ...deps }).continue(
+            {
+              url,
+              accessToken
+            },
+            { interact_ref }
+          )
+
+          expect(postSpy).toHaveBeenCalledWith(
+            deps,
+            { url, accessToken, body: { interact_ref } },
+            true
+          )
+        })
+        test('without interact_ref', async (): Promise<void> => {
+          jest
+            .spyOn(openApi, 'createResponseValidator')
+            .mockImplementation(mockResponseValidator as any)
+
+          const postSpy = jest.spyOn(requestors, 'post')
+          const body = {}
+
+          await createGrantRoutes({ openApi, client, ...deps }).continue(
+            {
+              url,
+              accessToken
+            },
+            body
+          )
+
+          expect(postSpy).toHaveBeenCalledWith(
+            deps,
+            { url, accessToken, body },
+            true
+          )
+        })
+        test('without body', async (): Promise<void> => {
+          jest
+            .spyOn(openApi, 'createResponseValidator')
+            .mockImplementation(mockResponseValidator as any)
+
+          const postSpy = jest.spyOn(requestors, 'post')
+
+          await createGrantRoutes({ openApi, client, ...deps }).continue({
             url,
             accessToken
-          },
-          { interact_ref }
-        )
+          })
 
-        expect(postSpy).toHaveBeenCalledWith(
-          deps,
-          { url, accessToken, body: { interact_ref } },
-          true
-        )
+          expect(postSpy).toHaveBeenCalledWith(deps, { url, accessToken }, true)
+        })
       })
     })
   })

--- a/packages/open-payments/src/client/grant.ts
+++ b/packages/open-payments/src/client/grant.ts
@@ -25,7 +25,7 @@ export interface GrantRoutes {
   ): Promise<PendingGrant | Grant>
   continue(
     postArgs: GrantOrTokenRequestArgs,
-    args: GrantContinuationRequest
+    args?: GrantContinuationRequest
   ): Promise<Grant | GrantContinuation>
   cancel(postArgs: GrantOrTokenRequestArgs): Promise<void>
 }

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -96,7 +96,7 @@ export type GrantRequest = {
   interact?: ASOperations['post-request']['requestBody']['content']['application/json']['interact']
 }
 export type GrantContinuationRequest = {
-  interact_ref: ASOperations['post-continue']['requestBody']['content']['application/json']['interact_ref']
+  interact_ref?: ASOperations['post-continue']['requestBody']['content']['application/json']['interact_ref']
 }
 export type PendingGrant = {
   interact: ASComponents['schemas']['interact-response']


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

Updates the client args so that the continue request does not require the `interact_ref` nor `body`. It was recently changed such that it can be undefined, but is still required like so:

```ts
client.grant.continue({ accessToken, url }, { interact_ref: undefined })
```

With these changes you can do:

```ts
client.grant.continue({ accessToken, url }, {})
```

or

```ts
client.grant.continue({ accessToken, url })
```


<!--
Provide a succinct description of what this pull request entails.
-->

## Context

small follow-up on https://github.com/interledger/open-payments/issues/433

Originally I made the PR for ergonomics sake on the client, but actually I think it will be necessary for continuation polling via the client (at least without adjusting auth server logic), since this is how we're checking whether or not to poll (condition wont be met with any `body.interact_ref`):

```ts
  if (!ctx.request.body || Object.keys(ctx.request.body).length === 0) {
    await pollGrantContinuation(deps, ctx, continueId, continueToken)
    return
  }
```

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
