### PR TITLE
chore(openapi): export OpenAPIValidatorMiddlewareError

### DIFF
--- a/.changeset/lazy-phones-sniff.md
+++ b/.changeset/lazy-phones-sniff.md
@@ -1,0 +1,5 @@
+---
+'@interledger/openapi': patch
+---
+
+- Exporting `OpenAPIValidatorMiddlewareError` from package

--- a/packages/openapi/src/index.ts
+++ b/packages/openapi/src/index.ts
@@ -9,7 +9,10 @@ import OpenAPIResponseValidator, {
 } from 'openapi-response-validator'
 import { OpenAPIV3, OpenAPIV3_1 } from 'openapi-types'
 
-export { createValidatorMiddleware } from './middleware'
+export {
+  createValidatorMiddleware,
+  OpenAPIValidatorMiddlewareError
+} from './middleware'
 
 export const HttpMethod = {
   ...OpenAPIV3.HttpMethods


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request
- Exporting out `OpenAPIValidatorMiddlewareError` from `openapi` package, forgot to do so in previous PR 🙃 

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
related to #445 
