### PR TITLE
feat: add option to create outgoing payment from incoming payment

### DIFF
--- a/.changeset/friendly-dryers-search.md
+++ b/.changeset/friendly-dryers-search.md
@@ -2,4 +2,4 @@
 '@interledger/open-payments': minor
 ---
 
-changes POST /outgoing-payment body and client's outgoingPayment.create args to accept incomingPaymentId and debitAmount as alternative to quoteId. This supports creating outgoing payments directly from incoming payments instead of from a quote.
+changes POST /outgoing-payment body and client's outgoingPayment.create args to accept incomingPayment and debitAmount as alternative to quoteId. This supports creating outgoing payments directly from incoming payments instead of from a quote.

--- a/.changeset/friendly-dryers-search.md
+++ b/.changeset/friendly-dryers-search.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+changes POST /outgoing-payment body and client's outgoingPayment.create args to accept incomingPaymentId and debitAmount as alternative to quoteId. This supports creating outgoing payments directly from incoming payments instead of from a quote.

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,1 +1,0 @@
-singleQuote: true

--- a/docs/src/content/docs/introduction/op-concepts.mdx
+++ b/docs/src/content/docs/introduction/op-concepts.mdx
@@ -90,12 +90,7 @@ When an `outgoing-payment` is completed against an open and active `incoming-pay
 
 To set up ILP as a payment method in OP, the following are required:
 
-- The <LinkOut href='https://interledger.org/developers/rfcs/ilp-addresses/'>ILP address
-  </LinkOut> of the payee’s ASE: The ILP address is required so that packets representing
-payments routed over the Interledger network will be forwarded to the node owned
-and operated by the intended receiver (i.e. payee's ASE). The `ilpAddress` field
-must be sent by the payee’s ASE in the `methods` object on an `incoming-payment`
-response.
+- The <LinkOut href='https://interledger.org/developers/rfcs/ilp-addresses/'>ILP address </LinkOut> of the payee’s ASE: The ILP address is required so that packets representing payments routed over the Interledger network will be forwarded to the node owned and operated by the intended receiver (i.e. payee's ASE). The `ilpAddress` field must be sent by the payee’s ASE in the `methods` object on an `incoming-payment` response.
 - Shared secret: A cryptographically secured secret exchanged between the sender and receiver to ensure that packets sent over the Interledger network through a <LinkOut href='https://interledger.org/developers/rfcs/stream-protocol/'>STREAM</LinkOut> connection can only be read by the two parties. The payee’s ASE must return the `sharedSecret` field in the `methods` object on an `incoming-payment` response.
 - The payee's ASE must return the value `ilp` in the `type` field of the `methods` object on an `incoming-payment` response.
 - The payer's ASE must send the value `ilp` in the `method` field when creating a `quote`.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -291,27 +291,60 @@ paths:
                   quoteId: 'https://ilp.rafiki.money/quotes/ab03296b-0c8b-4776-b94e-7ee27d868d4d'
                   metadata:
                     externalRef: INV2022-02-0137
+              Create an outgoing payment based on an incoming payment:
+                value:
+                  walletAddress: 'https://ilp.rafiki.money/alice/'
+                  incomingPaymentId: 'https://ilp.rafiki.money/incoming-payments/8d4e4776-2e55-4e5a-bcbe-8348ed1e86de'
+                  debitAmount:
+                    value: '2500'
+                    assetCode: USD
+                    assetScale: 2
+                  metadata:
+                    externalRef: INV2022-02-0137
             schema:
-              type: object
-              properties:
-                walletAddress:
-                  $ref: ./schemas.yaml#/components/schemas/walletAddress
-                quoteId:
-                  type: string
-                  format: uri
-                  description: The URL of the quote defining this payment's amounts.
-                metadata:
-                  type: object
-                  additionalProperties: true
-                  description: Additional metadata associated with the outgoing payment. (Optional)
-              required:
-                - quoteId
-                - walletAddress
-              additionalProperties: false
+              oneOf:
+                - type: object
+                  properties:
+                    walletAddress:
+                      $ref: ./schemas.yaml#/components/schemas/walletAddress
+                    quoteId:
+                      type: string
+                      format: uri
+                      description: The URL of the quote defining this payment's amounts.
+                    metadata:
+                      type: object
+                      additionalProperties: true
+                      description: Additional metadata associated with the outgoing payment. (Optional)
+                  required:
+                    - quoteId
+                    - walletAddress
+                  additionalProperties: false
+                - type: object
+                  properties:
+                    walletAddress:
+                      $ref: ./schemas.yaml#/components/schemas/walletAddress
+                    incomingPaymentId:
+                      type: string
+                      format: uri
+                      description: The URL of the incoming payment this outgoing payment will fulfill.
+                    debitAmount:
+                      description: The fixed amount that would be sent from the sending wallet address given a successful outgoing payment.
+                      $ref: ./schemas.yaml#/components/schemas/amount
+                    metadata:
+                      type: object
+                      additionalProperties: true
+                      description: Additional metadata associated with the outgoing payment. (Optional)
+                  required:
+                    - incomingPaymentId
+                    - debitAmount
+                    - walletAddress
+                  additionalProperties: false
         description: |-
           A subset of the outgoing payments schema is accepted as input to create a new outgoing payment.
 
           The `debitAmount` must use the same `assetCode` and `assetScale` as the wallet address.
+
+          Either provide a `quoteId` to create an outgoing payment based on a quote or provide `incomingPaymentId` and `debitAmount` to create an outgoing payment directly from an incoming payment.
         required: true
       description: |-
         An **outgoing payment** is a sub-resource of a wallet address. It represents a payment from the wallet address.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -294,7 +294,7 @@ paths:
               Create an outgoing payment based on an incoming payment:
                 value:
                   walletAddress: 'https://ilp.rafiki.money/alice/'
-                  incomingPaymentId: 'https://ilp.rafiki.money/incoming-payments/8d4e4776-2e55-4e5a-bcbe-8348ed1e86de'
+                  incomingPayment: 'https://ilp.rafiki.money/incoming-payments/8d4e4776-2e55-4e5a-bcbe-8348ed1e86de'
                   debitAmount:
                     value: '2500'
                     assetCode: USD
@@ -323,7 +323,7 @@ paths:
                   properties:
                     walletAddress:
                       $ref: ./schemas.yaml#/components/schemas/walletAddress
-                    incomingPaymentId:
+                    incomingPayment:
                       type: string
                       format: uri
                       description: The URL of the incoming payment this outgoing payment will fulfill.
@@ -335,7 +335,7 @@ paths:
                       additionalProperties: true
                       description: Additional metadata associated with the outgoing payment. (Optional)
                   required:
-                    - incomingPaymentId
+                    - incomingPayment
                     - debitAmount
                     - walletAddress
                   additionalProperties: false
@@ -344,7 +344,7 @@ paths:
 
           The `debitAmount` must use the same `assetCode` and `assetScale` as the wallet address.
 
-          Either provide a `quoteId` to create an outgoing payment based on a quote or provide `incomingPaymentId` and `debitAmount` to create an outgoing payment directly from an incoming payment.
+          Either provide a `quoteId` to create an outgoing payment based on a quote or provide `incomingPayment` and `debitAmount` to create an outgoing payment directly from an incoming payment.
         required: true
       description: |-
         An **outgoing payment** is a sub-resource of a wallet address. It represents a payment from the wallet address.

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -282,7 +282,7 @@ describe('outgoing-payment', (): void => {
 
   describe('createOutgoingPayment', (): void => {
     const quoteId_ = `${serverAddress}/quotes/${uuid()}`
-    const incomingPaymentId = `${serverAddress}/incoming-payments/${uuid()}`
+    const incomingPayment = `${serverAddress}/incoming-payments/${uuid()}`
     const debitAmount = {
       value: '2500',
       assetCode: 'USD',
@@ -290,21 +290,21 @@ describe('outgoing-payment', (): void => {
     }
 
     test.each`
-      quoteId      | incomingPaymentId    | debitAmount    | metadata                                                      | createSource
-      ${quoteId_}  | ${undefined}         | ${undefined}   | ${{ description: 'Some description', externalRef: '#INV-1' }} | ${'quote'}
-      ${quoteId_}  | ${undefined}         | ${undefined}   | ${undefined}                                                  | ${'quote'}
-      ${undefined} | ${incomingPaymentId} | ${debitAmount} | ${undefined}                                                  | ${'incoming payment'}
+      quoteId      | incomingPayment    | debitAmount    | metadata                                                      | createSource
+      ${quoteId_}  | ${undefined}       | ${undefined}   | ${{ description: 'Some description', externalRef: '#INV-1' }} | ${'quote'}
+      ${quoteId_}  | ${undefined}       | ${undefined}   | ${undefined}                                                  | ${'quote'}
+      ${undefined} | ${incomingPayment} | ${debitAmount} | ${undefined}                                                  | ${'incoming payment'}
     `(
       'creates outgoing payment from $createSource',
       async ({
         quoteId,
-        incomingPaymentId,
+        incomingPayment,
         debitAmount,
         metadata
       }): Promise<void> => {
-        // quoteId and incomingPaymentId/debitAmount should be mutually exclusive
-        assert(quoteId || (incomingPaymentId && debitAmount))
-        assert(!(quoteId && incomingPaymentId))
+        // quoteId and incomingPayment/debitAmount should be mutually exclusive
+        assert(quoteId || (incomingPayment && debitAmount))
+        assert(!(quoteId && incomingPayment))
         assert(!(quoteId && debitAmount))
 
         const outgoingPayment = mockOutgoingPayment({
@@ -318,7 +318,7 @@ describe('outgoing-payment', (): void => {
 
         const createOutgoingPaymentInput: CreateOutgoingPaymentArgs = quoteId
           ? { walletAddress, metadata, quoteId }
-          : { walletAddress, metadata, incomingPaymentId, debitAmount }
+          : { walletAddress, metadata, incomingPayment, debitAmount }
 
         const result = await createOutgoingPayment(
           deps,

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -417,7 +417,7 @@ export interface operations {
      *
      * The `debitAmount` must use the same `assetCode` and `assetScale` as the wallet address.
      *
-     * Either provide a `quoteId` to create an outgoing payment based on a quote or provide `incomingPaymentId` and `debitAmount` to create an outgoing payment directly from an incoming payment.
+     * Either provide a `quoteId` to create an outgoing payment based on a quote or provide `incomingPayment` and `debitAmount` to create an outgoing payment directly from an incoming payment.
      */
     requestBody: {
       content: {
@@ -438,7 +438,7 @@ export interface operations {
                * Format: uri
                * @description The URL of the incoming payment this outgoing payment will fulfill.
                */
-              incomingPaymentId: string;
+              incomingPayment: string;
               /** @description The fixed amount that would be sent from the sending wallet address given a successful outgoing payment. */
               debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
               /** @description Additional metadata associated with the outgoing payment. (Optional) */

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -416,19 +416,34 @@ export interface operations {
      * A subset of the outgoing payments schema is accepted as input to create a new outgoing payment.
      *
      * The `debitAmount` must use the same `assetCode` and `assetScale` as the wallet address.
+     *
+     * Either provide a `quoteId` to create an outgoing payment based on a quote or provide `incomingPaymentId` and `debitAmount` to create an outgoing payment directly from an incoming payment.
      */
     requestBody: {
       content: {
-        "application/json": {
-          walletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
-          /**
-           * Format: uri
-           * @description The URL of the quote defining this payment's amounts.
-           */
-          quoteId: string;
-          /** @description Additional metadata associated with the outgoing payment. (Optional) */
-          metadata?: { [key: string]: unknown };
-        };
+        "application/json":
+          | {
+              walletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
+              /**
+               * Format: uri
+               * @description The URL of the quote defining this payment's amounts.
+               */
+              quoteId: string;
+              /** @description Additional metadata associated with the outgoing payment. (Optional) */
+              metadata?: { [key: string]: unknown };
+            }
+          | {
+              walletAddress: external["schemas.yaml"]["components"]["schemas"]["walletAddress"];
+              /**
+               * Format: uri
+               * @description The URL of the incoming payment this outgoing payment will fulfill.
+               */
+              incomingPaymentId: string;
+              /** @description The fixed amount that would be sent from the sending wallet address given a successful outgoing payment. */
+              debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+              /** @description Additional metadata associated with the outgoing payment. (Optional) */
+              metadata?: { [key: string]: unknown };
+            };
       };
     };
   };


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->
- changes spec and test to allow createing outgoing payment  from `incomingPaymentId`/`debitAmount` instead of only `quoteId`

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

fixes https://github.com/interledger/open-payments/issues/415

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
