### PR TITLE
feat: return outgoing-payment-with-spent-amounts from POST /outgoing-payment

### DIFF
--- a/.changeset/shy-needles-brush.md
+++ b/.changeset/shy-needles-brush.md
@@ -1,5 +1,5 @@
 ---
-'@interledger/open-payments': major
+'@interledger/open-payments': minor
 ---
 
 Changes POST /outgoing-payment return to new 'outgoing-payment-with-spent-amounts' type with grantSpentDebitAmount and grantSpentReceiveAmount

--- a/.changeset/shy-needles-brush.md
+++ b/.changeset/shy-needles-brush.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': major
+---
+
+Changes POST /outgoing-payment return to new 'outgoing-payment-with-spent-amounts' type with grantSpentDebitAmount and grantSpentReceiveAmount

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -967,7 +967,6 @@ components:
           metadata:
             description: Thank you for your purchase at ShoeShop!
             externalRef: INV2022-8943756
-      additionalProperties: false
       properties:
         id:
           type: string

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -967,6 +967,7 @@ components:
           metadata:
             description: Thank you for your purchase at ShoeShop!
             externalRef: INV2022-8943756
+      additionalProperties: false
       properties:
         id:
           type: string

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1112,7 +1112,7 @@ components:
           description: The total amount that has been sent under this outgoing payment.
         grantSpentDebitAmount:
           $ref: './schemas.yaml#/components/schemas/amount'
-          description: The amount already deducted from the sender's account against the outgoing payment.
+          description: The total amount already deducted from the sender's account using the current outgoing payment grant.
         grantSpentReceiveAmount:
           $ref: './schemas.yaml#/components/schemas/amount'
           description: The total amount already received against the outgoing payment.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1045,6 +1045,27 @@ components:
             value: '2600'
             assetCode: USD
             assetScale: 2
+          createdAt: '2022-03-12T23:20:50.52Z'
+          updatedAt: '2022-04-01T10:24:36.11Z'
+          metadata:
+            description: APlusVideo subscription
+            externalRef: 'customer: 847458475'
+        - id: 'https://ilp.rafiki.money/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+          walletAddress: 'https://ilp.rafiki.money/alice/'
+          failed: false
+          receiver: 'https://ilp.rafiki.money/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
+          receiveAmount:
+            value: '2500'
+            assetCode: USD
+            assetScale: 2
+          debitAmount:
+            value: '2600'
+            assetCode: USD
+            assetScale: 2
+          sentAmount:
+            value: '2500'
+            assetCode: USD
+            assetScale: 2
           grantSpentReceiveAmount:
             value: '2500'
             assetCode: USD
@@ -1088,10 +1109,10 @@ components:
           description: The total amount that has been sent under this outgoing payment.
         grantSpentDebitAmount:
           $ref: './schemas.yaml#/components/schemas/amount'
-          description: The total amount already deducted from the sender's account using the current outgoing payment grant.
+          description: The total amount successfully deducted from the sender's account using the current outgoing payment grant.
         grantSpentReceiveAmount:
           $ref: './schemas.yaml#/components/schemas/amount'
-          description: The total amount already received (by all receivers) against the current outgoing payment grant.
+          description: The total amount successfully received (by all receivers) using the current outgoing payment grant.
         metadata:
           type: object
           description: Additional metadata associated with the outgoing payment. (Optional)
@@ -1112,8 +1133,6 @@ components:
         - sentAmount
         - createdAt
         - updatedAt
-        - grantSpentDebitAmount
-        - grantSpentReceiveAmount
     quote:
       title: Quote
       description: A **quote** resource represents the quoted amount details with which an Outgoing Payment may be created.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1090,7 +1090,7 @@ components:
           description: The total amount already deducted from the sender's account using the current outgoing payment grant.
         grantSpentReceiveAmount:
           $ref: './schemas.yaml#/components/schemas/amount'
-          description: The total amount already received against the outgoing payment.
+          description: The total amount already received (by all receivers) against the current outgoing payment grant.
         metadata:
           type: object
           description: Additional metadata associated with the outgoing payment. (Optional)

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1022,19 +1022,122 @@ components:
     outgoing-payment-with-spent-amounts:
       title: Outgoing Payment With Grant Spent Amounts
       description: 'An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the wallet address.'
-      allOf:
-        - $ref: '#/components/schemas/outgoing-payment'
-        - type: object
-          properties:
-            grantSpentDebitAmount:
-              $ref: './schemas.yaml#/components/schemas/amount'
-              description: The amount already deducted from the sender's account against the outgoing payment.
-            grantSpentReceiveAmount:
-              $ref: './schemas.yaml#/components/schemas/amount'
-              description: The total amount already received against the outgoing payment.
-          required:
-            - grantSpentDebitAmount
-            - grantSpentReceiveAmount
+      type: object
+      examples:
+        - id: 'https://ilp.rafiki.money/outgoing-payments/8c68d3cc-0a0f-4216-98b4-4fa44a6c88cf'
+          walletAddress: 'https://ilp.rafiki.money/alice/'
+          failed: false
+          receiver: 'https://ilp.rafiki.money/aplusvideo/incoming-payments/45d495ad-b763-4882-88d7-aa14d261686e'
+          receiveAmount:
+            value: '2500'
+            assetCode: USD
+            assetScale: 2
+          debitAmount:
+            value: '2600'
+            assetCode: USD
+            assetScale: 2
+          sentAmount:
+            value: '2500'
+            assetCode: USD
+            assetScale: 2
+          grantSpentDebitAmount:
+            value: '2600'
+            assetCode: USD
+            assetScale: 2
+          grantSpentReceiveAmount:
+            value: '2500'
+            assetCode: USD
+            assetScale: 2
+          createdAt: '2022-03-12T23:20:50.52Z'
+          updatedAt: '2022-04-01T10:24:36.11Z'
+          metadata:
+            description: APlusVideo subscription
+            externalRef: 'customer: 847458475'
+        - id: 'https://ilp.rafiki.money/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
+          walletAddress: 'https://ilp.rafiki.money/alice/'
+          failed: false
+          receiver: 'https://ilp.rafiki.money/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
+          debitAmount:
+            value: '7126'
+            assetCode: USD
+            assetScale: 2
+          sentAmount:
+            value: '7026'
+            assetCode: USD
+            assetScale: 2
+          grantSpentDebitAmount:
+            value: '7126'
+            assetCode: USD
+            assetScale: 2
+          grantSpentReceiveAmount:
+            value: '7026'
+            assetCode: USD
+            assetScale: 2
+          createdAt: '2022-03-12T23:20:50.52Z'
+          updatedAt: '2022-04-01T10:24:36.11Z'
+          metadata:
+            description: Thank you for your purchase at ShoeShop!
+            externalRef: INV2022-8943756
+      properties:
+        id:
+          type: string
+          format: uri
+          description: The URL identifying the outgoing payment.
+          readOnly: true
+        walletAddress:
+          type: string
+          format: uri
+          description: The URL of the wallet address from which this payment is sent.
+          readOnly: true
+        quoteId:
+          type: string
+          format: uri
+          description: The URL of the quote defining this payment's amounts.
+          readOnly: true
+        failed:
+          type: boolean
+          description: Describes whether the payment failed to send its full amount.
+          default: false
+        receiver:
+          $ref: ./schemas.yaml#/components/schemas/receiver
+          description: The URL of the incoming payment that is being paid.
+        receiveAmount:
+          $ref: ./schemas.yaml#/components/schemas/amount
+          description: The total amount that should be received by the receiver when this outgoing payment has been paid.
+        debitAmount:
+          $ref: ./schemas.yaml#/components/schemas/amount
+          description: The total amount that should be deducted from the sender's account when this outgoing payment has been paid.
+        sentAmount:
+          $ref: ./schemas.yaml#/components/schemas/amount
+          description: The total amount that has been sent under this outgoing payment.
+        grantSpentDebitAmount:
+          $ref: './schemas.yaml#/components/schemas/amount'
+          description: The amount already deducted from the sender's account against the outgoing payment.
+        grantSpentReceiveAmount:
+          $ref: './schemas.yaml#/components/schemas/amount'
+          description: The total amount already received against the outgoing payment.
+        metadata:
+          type: object
+          description: Additional metadata associated with the outgoing payment. (Optional)
+        createdAt:
+          type: string
+          format: date-time
+          description: The date and time when the outgoing payment was created.
+        updatedAt:
+          type: string
+          format: date-time
+          description: The date and time when the outgoing payment was updated.
+      required:
+        - id
+        - walletAddress
+        - receiver
+        - receiveAmount
+        - debitAmount
+        - sentAmount
+        - createdAt
+        - updatedAt
+        - grantSpentDebitAmount
+        - grantSpentReceiveAmount
     quote:
       title: Quote
       description: A **quote** resource represents the quoted amount details with which an Outgoing Payment may be created.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -253,7 +253,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/outgoing-payment'
+                $ref: '#/components/schemas/outgoing-payment-with-spent-amounts'
               examples:
                 New Fixed Send Outgoing Payment for $25:
                   value:
@@ -271,6 +271,14 @@ paths:
                       assetScale: 2
                     sentAmount:
                       value: '0'
+                      assetCode: USD
+                      assetScale: 2
+                    grantSpentDebitAmount:
+                      value: '2600'
+                      assetCode: USD
+                      assetScale: 2
+                    grantSpentReceiveAmount:
+                      value: '2500'
                       assetCode: USD
                       assetScale: 2
                     metadata:
@@ -1012,6 +1020,20 @@ components:
         - sentAmount
         - createdAt
         - updatedAt
+    outgoing-payment-with-spent-amounts:
+      allOf:
+        - $ref: '#/components/schemas/outgoing-payment'
+        - type: object
+          properties:
+            grantSpentDebitAmount:
+              $ref: './schemas.yaml#/components/schemas/amount'
+              description: The amount already deducted from the sender's account against the outgoing payment.
+            grantSpentReceiveAmount:
+              $ref: './schemas.yaml#/components/schemas/amount'
+              description: The total amount already received against the outgoing payment.
+          required:
+            - grantSpentDebitAmount
+            - grantSpentReceiveAmount
     quote:
       title: Quote
       description: A **quote** resource represents the quoted amount details with which an Outgoing Payment may be created.

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1053,31 +1053,6 @@ components:
           metadata:
             description: APlusVideo subscription
             externalRef: 'customer: 847458475'
-        - id: 'https://ilp.rafiki.money/outgoing-payments/0cffa5a4-58fd-4cc8-8e01-7145c72bf07c'
-          walletAddress: 'https://ilp.rafiki.money/alice/'
-          failed: false
-          receiver: 'https://ilp.rafiki.money/shoeshop/2fe92c6f-ef0d-487c-8759-3784eae6bce9'
-          debitAmount:
-            value: '7126'
-            assetCode: USD
-            assetScale: 2
-          sentAmount:
-            value: '7026'
-            assetCode: USD
-            assetScale: 2
-          grantSpentDebitAmount:
-            value: '7126'
-            assetCode: USD
-            assetScale: 2
-          grantSpentReceiveAmount:
-            value: '7026'
-            assetCode: USD
-            assetScale: 2
-          createdAt: '2022-03-12T23:20:50.52Z'
-          updatedAt: '2022-04-01T10:24:36.11Z'
-          metadata:
-            description: Thank you for your purchase at ShoeShop!
-            externalRef: INV2022-8943756
       properties:
         id:
           type: string

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -1021,6 +1021,8 @@ components:
         - createdAt
         - updatedAt
     outgoing-payment-with-spent-amounts:
+      title: Outgoing Payment With Grant Spent Amounts
+      description: 'An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the wallet address.'
       allOf:
         - $ref: '#/components/schemas/outgoing-payment'
         - type: object

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -8,6 +8,7 @@ import {
 import { OpenAPI, HttpMethod } from '@interledger/openapi'
 import {
   mockOutgoingPayment,
+  mockOutgoingPaymentWithSpentAmounts,
   mockOpenApiResponseValidators,
   mockOutgoingPaymentPaginationResult,
   createTestDeps
@@ -309,7 +310,7 @@ describe('outgoing-payment', (): void => {
         assert(!(quoteId && incomingPayment))
         assert(!(quoteId && debitAmount))
 
-        const outgoingPayment = mockOutgoingPayment({
+        const outgoingPayment = mockOutgoingPaymentWithSpentAmounts({
           quoteId: quoteId || uuid(),
           metadata
         })

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -188,6 +188,12 @@ export interface components {
        */
       updatedAt: string;
     };
+    "outgoing-payment-with-spent-amounts": components["schemas"]["outgoing-payment"] & {
+      /** @description The amount already deducted from the sender's account against the outgoing payment. */
+      grantSpentDebitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description The total amount already received against the outgoing payment. */
+      grantSpentReceiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+    };
     /**
      * Quote
      * @description A **quote** resource represents the quoted amount details with which an Outgoing Payment may be created.
@@ -406,7 +412,7 @@ export interface operations {
       /** Outgoing Payment Created */
       201: {
         content: {
-          "application/json": components["schemas"]["outgoing-payment"];
+          "application/json": components["schemas"]["outgoing-payment-with-spent-amounts"];
         };
       };
       401: components["responses"]["401"];

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -192,11 +192,48 @@ export interface components {
      * Outgoing Payment With Grant Spent Amounts
      * @description An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the wallet address.
      */
-    "outgoing-payment-with-spent-amounts": components["schemas"]["outgoing-payment"] & {
+    "outgoing-payment-with-spent-amounts": {
+      /**
+       * Format: uri
+       * @description The URL identifying the outgoing payment.
+       */
+      id: string;
+      /**
+       * Format: uri
+       * @description The URL of the wallet address from which this payment is sent.
+       */
+      walletAddress: string;
+      /**
+       * Format: uri
+       * @description The URL of the quote defining this payment's amounts.
+       */
+      quoteId?: string;
+      /** @description Describes whether the payment failed to send its full amount. */
+      failed?: boolean;
+      /** @description The URL of the incoming payment that is being paid. */
+      receiver: external["schemas.yaml"]["components"]["schemas"]["receiver"];
+      /** @description The total amount that should be received by the receiver when this outgoing payment has been paid. */
+      receiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description The total amount that should be deducted from the sender's account when this outgoing payment has been paid. */
+      debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description The total amount that has been sent under this outgoing payment. */
+      sentAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The amount already deducted from the sender's account against the outgoing payment. */
       grantSpentDebitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount already received against the outgoing payment. */
       grantSpentReceiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description Additional metadata associated with the outgoing payment. (Optional) */
+      metadata?: { [key: string]: unknown };
+      /**
+       * Format: date-time
+       * @description The date and time when the outgoing payment was created.
+       */
+      createdAt: string;
+      /**
+       * Format: date-time
+       * @description The date and time when the outgoing payment was updated.
+       */
+      updatedAt: string;
     };
     /**
      * Quote

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -218,10 +218,10 @@ export interface components {
       debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that has been sent under this outgoing payment. */
       sentAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description The total amount already deducted from the sender's account using the current outgoing payment grant. */
-      grantSpentDebitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description The total amount already received (by all receivers) against the current outgoing payment grant. */
-      grantSpentReceiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description The total amount successfully deducted from the sender's account using the current outgoing payment grant. */
+      grantSpentDebitAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
+      /** @description The total amount successfully received (by all receivers) using the current outgoing payment grant. */
+      grantSpentReceiveAmount?: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description Additional metadata associated with the outgoing payment. (Optional) */
       metadata?: { [key: string]: unknown };
       /**

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -188,6 +188,10 @@ export interface components {
        */
       updatedAt: string;
     };
+    /**
+     * Outgoing Payment With Grant Spent Amounts
+     * @description An **outgoing payment** resource represents a payment that will be, is currently being, or has previously been, sent from the wallet address.
+     */
     "outgoing-payment-with-spent-amounts": components["schemas"]["outgoing-payment"] & {
       /** @description The amount already deducted from the sender's account against the outgoing payment. */
       grantSpentDebitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -218,9 +218,9 @@ export interface components {
       debitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description The total amount that has been sent under this outgoing payment. */
       sentAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description The amount already deducted from the sender's account against the outgoing payment. */
+      /** @description The total amount already deducted from the sender's account using the current outgoing payment grant. */
       grantSpentDebitAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
-      /** @description The total amount already received against the outgoing payment. */
+      /** @description The total amount already received (by all receivers) against the current outgoing payment grant. */
       grantSpentReceiveAmount: external["schemas.yaml"]["components"]["schemas"]["amount"];
       /** @description Additional metadata associated with the outgoing payment. (Optional) */
       metadata?: { [key: string]: unknown };

--- a/packages/open-payments/src/test/helpers.ts
+++ b/packages/open-payments/src/test/helpers.ts
@@ -17,7 +17,8 @@ import {
   IncomingPaymentWithPaymentMethods,
   IlpPaymentMethod,
   PublicIncomingPayment,
-  DIDDocument
+  DIDDocument,
+  OutgoingPaymentWithSpentAmounts
 } from '../types'
 import { v4 as uuid } from 'uuid'
 import { ResponseValidator, ValidationError } from '@interledger/openapi'
@@ -190,6 +191,23 @@ export const mockOutgoingPayment = (
   metadata: { externalRef: 'INV #1', description: 'some description' },
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
+  ...overrides
+})
+
+export const mockOutgoingPaymentWithSpentAmounts = (
+  overrides?: Partial<OutgoingPaymentWithSpentAmounts>
+): OutgoingPaymentWithSpentAmounts => ({
+  ...mockOutgoingPayment(),
+  grantSpentDebitAmount: {
+    assetCode: 'USD',
+    assetScale: 2,
+    value: '10'
+  },
+  grantSpentReceiveAmount: {
+    assetCode: 'USD',
+    assetScale: 2,
+    value: '10'
+  },
   ...overrides
 })
 

--- a/packages/open-payments/src/types.ts
+++ b/packages/open-payments/src/types.ts
@@ -38,6 +38,8 @@ export type CreateIncomingPaymentArgs =
   RSOperations['create-incoming-payment']['requestBody']['content']['application/json']
 export type IncomingPaymentPaginationResult = PaginationResult<IncomingPayment>
 export type OutgoingPayment = RSComponents['schemas']['outgoing-payment']
+export type OutgoingPaymentWithSpentAmounts =
+  RSComponents['schemas']['outgoing-payment-with-spent-amounts']
 export type CreateOutgoingPaymentArgs =
   RSOperations['create-outgoing-payment']['requestBody']['content']['application/json']
 type PaginationResult<T> = {


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

- changes `POST /outgoing-payment` return type to new `outgoing-payment-with-spent-amounts` which extends existing `outgoing-payment` with new required fields `grantSpentDebitAmount` and `grantSpentReceiveAmount`.

<!--
Provide a succinct description of what this pull request entails.
-->

## Context
fixes: https://github.com/interledger/open-payments/issues/469

progress towards: https://github.com/interledger/rafiki/issues/2678

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
