### PR TITLE
chore: export OutgoingPaymentWithSpentAmounts

### DIFF
--- a/.changeset/little-lobsters-yell.md
+++ b/.changeset/little-lobsters-yell.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': patch
+---
+
+Export OutgoingPaymentWithSpentAmounts

--- a/packages/open-payments/src/index.ts
+++ b/packages/open-payments/src/index.ts
@@ -8,6 +8,7 @@ export {
   IlpPaymentMethod,
   Quote,
   OutgoingPayment,
+  OutgoingPaymentWithSpentAmounts,
   PendingGrant,
   Grant,
   isPendingGrant,


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

exports `OutgoingPaymentWithSpentAmounts`  type

## Context

missed in  https://github.com/interledger/open-payments/pull/474
