### PR TITLE
chore(open-payments): parse error objects, and return error codes

### DIFF
--- a/.changeset/warm-geese-rescue.md
+++ b/.changeset/warm-geese-rescue.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': minor
+---
+
+Adding functionality to parse error objects from Open Payments API responses, and expose new `code` field in `OpenPaymentsClientError`.

--- a/packages/open-payments/README.md
+++ b/packages/open-payments/README.md
@@ -104,6 +104,7 @@ try {
 } catch (error) {
   if (error instanceof OpenPaymentsClientError) {
     console.log(error.message)
+    console.log(error.code) // the error code from the Open Payments API
     console.log(error.description) // additional description of the error
     console.log(error.status) // the HTTP status of the request, if a request failure
     console.log(error.validationErrors) // an array of validation errors. Populated if the response of the request failed OpenAPI specfication validation, or other validation checks.

--- a/packages/open-payments/README.md
+++ b/packages/open-payments/README.md
@@ -104,9 +104,9 @@ try {
 } catch (error) {
   if (error instanceof OpenPaymentsClientError) {
     console.log(error.message)
-    console.log(error.code) // the error code from the Open Payments API
     console.log(error.description) // additional description of the error
     console.log(error.status) // the HTTP status of the request, if a request failure
+    console.log(error.code) // the error code from the Open Payments API
     console.log(error.validationErrors) // an array of validation errors. Populated if the response of the request failed OpenAPI specfication validation, or other validation checks.
   } else {
     console.log(error)

--- a/packages/open-payments/src/client/error.ts
+++ b/packages/open-payments/src/client/error.ts
@@ -1,6 +1,7 @@
 interface ErrorDetails {
   description: string
   status?: number
+  code?: string
   validationErrors?: string[]
 }
 
@@ -8,12 +9,14 @@ export class OpenPaymentsClientError extends Error {
   public description: string
   public validationErrors?: string[]
   public status?: number
+  public code?: string
 
   constructor(message: string, args: ErrorDetails) {
     super(message)
     this.name = 'OpenPaymentsClientError'
     this.description = args.description
     this.status = args.status
+    this.code = args.code
     this.validationErrors = args.validationErrors
   }
 }

--- a/packages/open-payments/src/client/index.test.ts
+++ b/packages/open-payments/src/client/index.test.ts
@@ -75,6 +75,7 @@ describe('Client', (): void => {
     })
 
     test('throws error if could not load private key as Buffer', async (): Promise<void> => {
+      expect.assertions(2)
       try {
         await createAuthenticatedClient({
           logger: silentLogger,
@@ -92,6 +93,7 @@ describe('Client', (): void => {
     })
 
     test('throws error if could not load private key', async (): Promise<void> => {
+      expect.assertions(2)
       try {
         await createAuthenticatedClient({
           logger: silentLogger,
@@ -116,6 +118,7 @@ describe('Client', (): void => {
     `(
       'throws an error if both authenticatedRequestInterceptor and privateKey or keyId are provided',
       async ({ keyId, privateKey }) => {
+        expect.assertions(2)
         try {
           // @ts-expect-error Invalid args
           await createAuthenticatedClient({

--- a/packages/open-payments/src/client/outgoing-payment.test.ts
+++ b/packages/open-payments/src/client/outgoing-payment.test.ts
@@ -235,6 +235,7 @@ describe('outgoing-payment', (): void => {
         .query({ 'wallet-address': walletAddress })
         .reply(200, outgoingPaymentPaginationResult)
 
+      expect.assertions(3)
       try {
         await listOutgoingPayments(
           deps,
@@ -278,7 +279,7 @@ describe('outgoing-payment', (): void => {
           },
           openApiValidators.failedValidator
         )
-      ).rejects.toThrowError()
+      ).rejects.toThrow()
       scope.done()
     })
   })
@@ -355,6 +356,7 @@ describe('outgoing-payment', (): void => {
         .post('/outgoing-payments')
         .reply(200, outgoingPayment)
 
+      expect.assertions(3)
       try {
         await createOutgoingPayment(
           deps,
@@ -402,7 +404,7 @@ describe('outgoing-payment', (): void => {
             walletAddress
           }
         )
-      ).rejects.toThrowError(OpenPaymentsClientError)
+      ).rejects.toThrow(OpenPaymentsClientError)
       scope.done()
     })
   })

--- a/packages/open-payments/src/client/requests.ts
+++ b/packages/open-payments/src/client/requests.ts
@@ -183,9 +183,7 @@ export const handleError = async (
         ? responseBody.error?.description || JSON.stringify(responseBody)
         : responseBody || error.message
     errorCode =
-      typeof responseBody === 'object' && responseBody.error?.code
-        ? responseBody.error.code
-        : undefined
+      typeof responseBody === 'object' ? responseBody.error?.code : undefined
   } else if (isValidationError(error)) {
     errorDescription = 'Could not validate OpenAPI response'
     validationErrors = error.errors.map((e) => e.message)

--- a/packages/open-payments/src/client/requests.ts
+++ b/packages/open-payments/src/client/requests.ts
@@ -149,7 +149,7 @@ interface HandleErrorArgs {
   requestType: 'POST' | 'DELETE' | 'GET'
 }
 
-const handleError = async (
+export const handleError = async (
   deps: BaseDeps,
   args: HandleErrorArgs
 ): Promise<never> => {
@@ -158,23 +158,34 @@ const handleError = async (
   let errorDescription
   let errorStatus
   let validationErrors
+  let errorCode
 
   const { HTTPError } = await import('ky')
 
   if (error instanceof HTTPError) {
-    let responseBody
+    let responseBody:
+      | {
+          error: { description: string; code: string }
+        }
+      | string
+      | undefined
 
     try {
-      responseBody = (await error.response.json()) as { message: string }
+      responseBody = await error.response.text()
+      responseBody = JSON.parse(responseBody)
     } catch {
       // Ignore if we can't parse the response body (or no body exists)
     }
 
+    errorStatus = error.response.status
     errorDescription =
-      responseBody && responseBody.message
-        ? responseBody.message
-        : error.message
-    errorStatus = error.response?.status
+      typeof responseBody === 'object'
+        ? responseBody.error?.description || JSON.stringify(responseBody)
+        : responseBody || error.message
+    errorCode =
+      typeof responseBody === 'object' && responseBody.error?.code
+        ? responseBody.error.code
+        : undefined
   } else if (isValidationError(error)) {
     errorDescription = 'Could not validate OpenAPI response'
     validationErrors = error.errors.map((e) => e.message)
@@ -188,14 +199,21 @@ const handleError = async (
 
   const errorMessage = `Error making Open Payments ${requestType} request`
   deps.logger.error(
-    { status: errorStatus, errorDescription, url, requestType },
+    {
+      method: requestType,
+      url,
+      status: errorStatus,
+      description: errorDescription,
+      code: errorCode
+    },
     errorMessage
   )
 
   throw new OpenPaymentsClientError(errorMessage, {
     description: errorDescription,
     validationErrors,
-    status: errorStatus
+    status: errorStatus,
+    code: errorCode
   })
 }
 


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request
Now that we are returning the following error response from the AS:
```json
{
    "error": {
        "code": "invalid_client",
        "description": "could not determine client"
    }
}
```

we now populate `code` and `description` fields in the `OpenPaymentsClientError` with the correct values.

## Context
- Fixes #482
