### PR TITLE
fix(open-payments): change outgoingPayment.create return type

### DIFF
--- a/.changeset/eight-cups-reflect.md
+++ b/.changeset/eight-cups-reflect.md
@@ -1,5 +1,5 @@
 ---
-'@interledger/open-payments': major
+'@interledger/open-payments': patch
 ---
 
-Changes return type of outgoingPayment.create to OutgoingPaymentWithSpentAmounts to reflect correct return type. Consumers should update code to account for new return type as needed.
+Changes return type of outgoingPayment.create to OutgoingPaymentWithSpentAmounts to reflect correct return type.

--- a/.changeset/eight-cups-reflect.md
+++ b/.changeset/eight-cups-reflect.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': major
+---
+
+Changes return type of outgoingPayment.create to OutgoingPaymentWithSpentAmounts to reflect correct return type. Consumers should update code to account for new return type as needed.

--- a/packages/open-payments/src/client/outgoing-payment.ts
+++ b/packages/open-payments/src/client/outgoing-payment.ts
@@ -10,6 +10,7 @@ import {
   getRSPath,
   OutgoingPayment,
   OutgoingPaymentPaginationResult,
+  OutgoingPaymentWithSpentAmounts,
   PaginationArgs
 } from '../types'
 import { get, post } from './requests'
@@ -24,7 +25,7 @@ export interface OutgoingPaymentRoutes {
   create(
     requestArgs: ResourceRequestArgs,
     createArgs: CreateOutgoingPaymentArgs
-  ): Promise<OutgoingPayment>
+  ): Promise<OutgoingPaymentWithSpentAmounts>
 }
 
 export const createOutgoingPaymentRoutes = (


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->
- updates return type of create outgoing payment method on the open payments client

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

fixes issue raised in this comment: https://github.com/interledger/open-payments/pull/480#issuecomment-2202353862

looks like it was probably first encountered here https://github.com/interledger/web-monetization-extension/pull/386/files