### PR TITLE
feat: add access-identity to auth-server.yaml

### DIFF
--- a/openapi/auth-server.yaml
+++ b/openapi/auth-server.yaml
@@ -313,6 +313,7 @@ components:
         - $ref: '#/components/schemas/access-incoming'
         - $ref: '#/components/schemas/access-outgoing'
         - $ref: '#/components/schemas/access-quote'
+        - $ref: '#/components/schemas/access-identity'
       description: The access associated with the access token is described using objects that each contain multiple dimensions of access.
       unevaluatedProperties: false
     access-incoming:
@@ -371,6 +372,27 @@ components:
           description: A string identifier indicating a specific resource at the RS.
         limits:
           $ref: '#/components/schemas/limits-outgoing'
+      required:
+        - type
+        - actions
+        - identifier
+    access-identity:
+      title: access-identity
+      type: object
+      properties:
+        type:
+          type: string
+          enum:
+            - user-identity
+          description: The type of resource request as a string.  This field defines which other fields are allowed in the request object.
+        actions:
+          type: array
+          description: The types of actions the client instance will take at the RS as an array of strings.
+          items:
+            type: string
+            enum:
+              - read
+          uniqueItems: true
       required:
         - type
         - actions


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

This PR is a proposal for a new grant type: `access-identity`

## Context

As part of the [Open Payments community call](https://docs.google.com/document/d/1b3caT7lWAaTA-rZMI3YTDBgInGWVa7JtMuO17vG84kg/edit?usp=sharing), the need for a user-authentication grant was identified by two participants. One of the actions from the latest call was to create proposals. This is one such proposal.

## TODO

- [ ] Update `resource-server.yaml`
- [ ] Create basic example docs
