### PR TITLE
chore: removed Glossary page's overview section

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -12,7 +12,8 @@ export default defineConfig({
       description:
         'An API for open access to financial accounts to send and receive payments.',
       components: {
-        Header: './src/components/Header.astro'
+        Header: './src/components/Header.astro',
+        PageSidebar: './src/components/PageSidebar.astro'
       },
       customCss: [
         './node_modules/@interledger/docs-design-system/src/styles/teal-theme.css',

--- a/docs/src/components/PageSidebar.astro
+++ b/docs/src/components/PageSidebar.astro
@@ -1,0 +1,17 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageSidebar.astro';
+
+const removeOverview = [
+ 'resources/glossary',
+]
+const noOverview = removeOverview.includes(Astro.props.slug);
+const toc = noOverview && Astro.props.toc !== undefined
+	? {
+			...Astro.props.toc,
+			items: Astro.props.toc?.items.slice(1),
+	  } 
+	: Astro.props.toc;
+---
+
+<Default {...Astro.props} {toc}><slot /></Default>


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Removing the sidebar Overview item on the OP docs glossary page.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
