### PR TITLE
feat: added basic site tracking using Umami

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -11,6 +11,17 @@ export default defineConfig({
       title: 'Open Payments',
       description:
         'An API for open access to financial accounts to send and receive payments.',
+      head: [
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            'data-website-id': '76afa57f-78bb-48ab-a9e4-095a32d8a1b9',
+            src: 'https://ilf-site-analytics.netlify.app/script.js',
+            'data-domains': 'openpayments.dev'
+          }
+        }
+      ],
       components: {
         Header: './src/components/Header.astro',
         PageSidebar: './src/components/PageSidebar.astro'

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,9 +9,13 @@ hero:
       link: introduction/overview/
       icon: open-book
       variant: primary
+      attrs:
+        data-umami-event: Landing page - OP docs
     - text: View on GitHub
       icon: external
       link: https://github.com/interledger/open-payments
+      attrs:
+        data-umami-event: Landing page - OP GitHub
 ---
 
 import { Card, CardGrid } from '@astrojs/starlight/components'


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Added an Umami site tracking script so that we can record page visits for the Open Payments docs.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

This gets the basic infrastructure in place and allows us to track page views. There will be more work needed to add granular event tracking based on clicking links.  
