### PR TITLE
chore: replacing .guide with .dev

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -49,7 +49,7 @@ The team will review your pull request as soon as possible.
 
 ### :books: Documentation
 
-We started to maintain public-facing documentation for Open Payments on [openpayments.guide](https://github.com/interledger/open-payments/tree/main/docs). The project is new, and available documentation is currently WIP.
+We started to maintain public-facing documentation for Open Payments on [openpayments.dev](https://github.com/interledger/open-payments/tree/main/docs). The project is new, and available documentation is currently WIP.
 
 ## Working in the Open Payments repository
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # OpenPayments API documentation
 
-This repo is the code behind [openpayments.guide](https://openpayments.guide), the documentation website for the OpenPayments API.
+This repo is the code behind [openpayments.dev](https://openpayments.dev), the documentation website for the OpenPayments API.
 
 ## Contribute
 
@@ -32,7 +32,7 @@ This command generates static content into the build directory and can be served
 
 ## Editing Content
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name. Due to the nature of how Starlight deals with content and their generated URLs, all docs content lives in `/src/content/docs/`. For example, the home page of the documentation lives within the `/src/content/docs/` folder and is rendered at openpayments.guide, not openpayments.guide/docs.
+Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name. Due to the nature of how Starlight deals with content and their generated URLs, all docs content lives in `/src/content/docs/`. For example, the home page of the documentation lives within the `/src/content/docs/` folder and is rendered at openpayments.dev, not openpayments.dev/docs.
 
 Static assets, like favicons or images, can be placed in the `public/` directory. When referencing these assets in your markdown, you do not have to include `public/` in the file path, so an image would have a path like:
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -5,7 +5,7 @@ import starlightLinksValidator from 'starlight-links-validator'
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://openpayments.guide',
+  site: 'https://openpayments.dev',
   integrations: [
     starlight({
       title: 'Open Payments',

--- a/docs/public/CNAME
+++ b/docs/public/CNAME
@@ -1,1 +1,1 @@
-openpayments.guide/
+openpayments.dev/

--- a/docs/src/content/docs/guides/create-interactive-grant.mdx
+++ b/docs/src/content/docs/guides/create-interactive-grant.mdx
@@ -24,10 +24,10 @@ Grants for creating incoming payment and quote resources are non-interactive by 
 
 ## Endpoints
 
-- <LinkOut href='https://openpayments.guide/apis/auth-server/operations/post-request/'>
+- <LinkOut href='https://openpayments.dev/apis/auth-server/operations/post-request/'>
     Grant Request
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/auth-server/operations/post-continue/'>
+- <LinkOut href='https://openpayments.dev/apis/auth-server/operations/post-continue/'>
     Continuation Request
   </LinkOut>
 

--- a/docs/src/content/docs/guides/make-onetime-payment.mdx
+++ b/docs/src/content/docs/guides/make-onetime-payment.mdx
@@ -22,19 +22,19 @@ Examples of use cases for a one-time payment might be an e-commerce or a money t
 
 ## Endpoints
 
-- <LinkOut href='https://openpayments.guide/apis/auth-server/operations/post-request/'>
+- <LinkOut href='https://openpayments.dev/apis/auth-server/operations/post-request/'>
     Grant Request
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/wallet-address-server/operations/get-wallet-address/'>
+- <LinkOut href='https://openpayments.dev/apis/wallet-address-server/operations/get-wallet-address/'>
     Get a Wallet address
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-incoming-payment/'>
+- <LinkOut href='https://openpayments.dev/apis/resource-server/operations/create-incoming-payment/'>
     Create an Incoming Payment
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-quote/'>
+- <LinkOut href='https://openpayments.dev/apis/resource-server/operations/create-quote/'>
     Create a Quote
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-outgoing-payment/'>
+- <LinkOut href='https://openpayments.dev/apis/resource-server/operations/create-outgoing-payment/'>
     Create an Outgoing Payment
   </LinkOut>
 
@@ -129,7 +129,7 @@ Add the `limits` object with the following properties:
 :::note
 This request requires an interactive grant as the payer will need to consent before an `outgoingPayment` is made against their wallet.
 
-For details on how to facilitate an interactive grant please see the <LinkOut href='https://openpayments.guide/guides/create-interactive-grant/'>
+For details on how to facilitate an interactive grant please see the <LinkOut href='https://openpayments.dev/guides/create-interactive-grant/'>
 Create an Interactive Grant guide. </LinkOut>
 :::
 

--- a/docs/src/content/docs/guides/make-recurring-payments.mdx
+++ b/docs/src/content/docs/guides/make-recurring-payments.mdx
@@ -22,19 +22,19 @@ An example use case for making recurring payments may be a Buy Now Pay Later (BN
 
 ## Endpoints
 
-- <LinkOut href='https://openpayments.guide/apis/auth-server/operations/post-request/'>
+- <LinkOut href='https://openpayments.dev/apis/auth-server/operations/post-request/'>
     Grant Request
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/wallet-address-server/operations/get-wallet-address/'>
+- <LinkOut href='https://openpayments.dev/apis/wallet-address-server/operations/get-wallet-address/'>
     Get a Wallet address
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-incoming-payment/'>
+- <LinkOut href='https://openpayments.dev/apis/resource-server/operations/create-incoming-payment/'>
     Create an Incoming Payment
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-quote/'>
+- <LinkOut href='https://openpayments.dev/apis/resource-server/operations/create-quote/'>
     Create a Quote
   </LinkOut>
-- <LinkOut href='https://openpayments.guide/apis/resource-server/operations/create-outgoing-payment/'>
+- <LinkOut href='https://openpayments.dev/apis/resource-server/operations/create-outgoing-payment/'>
     Create an Outgoing Payment
   </LinkOut>
 - <LinkOut href='https://openpayments.dev/apis/auth-server/operations/post-token/'>
@@ -133,7 +133,7 @@ Add the `limits` object with the following properties:
 :::note
 This request requires an interactive grant as the payer will need to consent before an `outgoingPayment` is made against their wallet.
 
-For details on how to facilitate an interactive grant please see the <LinkOut href='https://openpayments.guide/guides/create-interactive-grant/'>
+For details on how to facilitate an interactive grant please see the <LinkOut href='https://openpayments.dev/guides/create-interactive-grant/'>
 Create an Interactive Grant guide. </LinkOut>
 :::
 

--- a/packages/http-signature-utils/README.md
+++ b/packages/http-signature-utils/README.md
@@ -7,7 +7,7 @@ This library provides tools for working with [HTTP Message Signatures](https://d
 - Creating HTTP Signature headers & digests
 - Validating and verifying HTTP Signature headers
 
-HTTP Message Signatures are used for protecting the integrity of [Open Payments](https://openpayments.guide/introduction/http-signatures/) API requests.
+HTTP Message Signatures are used for protecting the integrity of [Open Payments](https://openpayments.dev/introduction/http-signatures/) API requests.
 
 ## Installation
 

--- a/packages/open-payments/README.md
+++ b/packages/open-payments/README.md
@@ -1,8 +1,8 @@
 # Open Payments
 
-[Open Payments](https://openpayments.guide/) is an API standard that allows third-parties (with the account holder's consent) to initiate payments and to view the transaction history on the account holder's account.
+[Open Payments](https://openpayments.dev/) is an API standard that allows third-parties (with the account holder's consent) to initiate payments and to view the transaction history on the account holder's account.
 
-Open Payments consists of two OpenAPI specifications, a **resource server** which exposes APIs for performing functions against the underlying accounts and an **authorization server** which exposes APIs compliant with the [GNAP](https://openpayments.guide/introduction/grants/) standard for getting grants to access the resource server APIs.
+Open Payments consists of two OpenAPI specifications, a **resource server** which exposes APIs for performing functions against the underlying accounts and an **authorization server** which exposes APIs compliant with the [GNAP](https://openpayments.dev/introduction/grants/) standard for getting grants to access the resource server APIs.
 
 This package provides TypeScript & NodeJS tools for using Open Payments:
 
@@ -34,7 +34,7 @@ This package exports two clients, an `UnauthenticatedClient` and an `Authenticat
 ### `UnauthenticatedClient`
 
 This client allows making requests to access publicly available resources, without needing to provide a private key (authentication).
-The available resources are [Wallet Addresses](https://openpayments.guide/apis/wallet-address-server/operations/get-wallet-address/), [Wallet Address Keys](https://openpayments.guide/apis/wallet-address-server/operations/get-wallet-address-keys/), and the public version of [Incoming Payments](https://openpayments.guide/apis/resource-server/operations/get-incoming-payment/).
+The available resources are [Wallet Addresses](https://openpayments.dev/apis/wallet-address-server/operations/get-wallet-address/), [Wallet Address Keys](https://openpayments.dev/apis/wallet-address-server/operations/get-wallet-address-keys/), and the public version of [Incoming Payments](https://openpayments.dev/apis/resource-server/operations/get-incoming-payment/).
 
 ```ts
 import { createUnauthenticatedClient } from '@interledger/open-payments'
@@ -75,11 +75,11 @@ const client = await createAuthenticatedClient({
 
 In order to create the client, three properties need to be provided: `keyId`, the `privateKey` and the `walletAddressUrl`:
 
-| Variable           | Description                                                                                                                                                                                                                                                                                                                                                                                             |
-| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `walletAddressUrl` | The valid wallet address with which the client making requests will identify itself. A JSON Web Key Set document that includes the public key that the client instance will use to protect requests MUST be available at the `{walletAddressUrl}/jwks.json` url. This will be used as the `client` field during [Grant Creation](https://openpayments.guide/apis/auth-server/operations/post-request/). |
-| `privateKey`       | The private EdDSA-Ed25519 key (or the relative or absolute path to the key) bound to the wallet address, and used to sign the authenticated requests with. As mentioned above, a public JWK document signed with this key MUST be available at the `{walletAddressUrl}/jwks.json` url.                                                                                                                  |
-| `keyId`            | The key identifier of the given private key and the corresponding public JWK document.                                                                                                                                                                                                                                                                                                                  |
+| Variable           | Description                                                                                                                                                                                                                                                                                                                                                                                           |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `walletAddressUrl` | The valid wallet address with which the client making requests will identify itself. A JSON Web Key Set document that includes the public key that the client instance will use to protect requests MUST be available at the `{walletAddressUrl}/jwks.json` url. This will be used as the `client` field during [Grant Creation](https://openpayments.dev/apis/auth-server/operations/post-request/). |
+| `privateKey`       | The private EdDSA-Ed25519 key (or the relative or absolute path to the key) bound to the wallet address, and used to sign the authenticated requests with. As mentioned above, a public JWK document signed with this key MUST be available at the `{walletAddressUrl}/jwks.json` url.                                                                                                                |
+| `keyId`            | The key identifier of the given private key and the corresponding public JWK document.                                                                                                                                                                                                                                                                                                                |
 
 > **Note**
 >
@@ -118,7 +118,7 @@ try {
 
 > **Note**
 >
-> A high level Open Payments flow with diagrams can be found [here](https://openpayments.guide/introduction/op-flow/).
+> A high level Open Payments flow with diagrams can be found [here](https://openpayments.dev/introduction/op-flow/).
 
 As mentioned previously, Open Payments APIs can facilitate a payment between two parties.
 


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

The docs were moved from .guide to .dev so I'm just updating mentions.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
