### PR TITLE
fix(docs): add additonal step for grant continuation

### DIFF
--- a/docs/src/content/docs/snippets/grant-continue.mdx
+++ b/docs/src/content/docs/snippets/grant-continue.mdx
@@ -47,6 +47,11 @@ These code snippets enable an authorized client to send a grant continuation req
   chunk='4'
 />
 
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-continuation.ts'
+  chunk='5'
+/>
+
 Run `tsx path/to/directory/index.ts`.
 
 {/* prettier-ignore */}
@@ -79,6 +84,11 @@ Run `tsx path/to/directory/index.ts`.
 <ChunkedSnippet
   source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-continuation.ts'
   chunk='4'
+/>
+
+<ChunkedSnippet
+  source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-continuation.ts'
+  chunk='5'
 />
 
 Run `node path/to/directory/index.js`.


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

Adds the additional step for grant continuation that was missing in the docs and snippet, where we check if the grant is finalized.

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
