### PR TITLE
docs: mi/update-recurring-payments-guide

### DIFF
--- a/docs/src/content/docs/guides/make-recurring-payments.mdx
+++ b/docs/src/content/docs/guides/make-recurring-payments.mdx
@@ -158,6 +158,10 @@ Add the following properties:
 
 ### 9. Rotate the Access Token
 
+:::note
+This step is only required if the access token you obtained in the previous `outgoingPayment` grant request has expired.
+:::
+
 Rotate the access token obtained from the previous `outgoingPayment` grant request.
 
 <ChunkedSnippet


### PR DESCRIPTION
Added note that rotating a token is only necessary when the previous token has expired.