### PR TITLE
chore(open-payments): update incoming payment metadata type

### DIFF
--- a/.changeset/grumpy-clouds-shave.md
+++ b/.changeset/grumpy-clouds-shave.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': patch
+---
+
+Adding correct type for incoming payment creation metadata field

--- a/openapi/resource-server.yaml
+++ b/openapi/resource-server.yaml
@@ -100,6 +100,7 @@ paths:
                   writeOnly: true
                 metadata:
                   type: object
+                  additionalProperties: true
                   description: Additional metadata associated with the incoming payment. (Optional)
               required:
                 - walletAddress

--- a/packages/open-payments/src/openapi/generated/resource-server-types.ts
+++ b/packages/open-payments/src/openapi/generated/resource-server-types.ts
@@ -524,7 +524,9 @@ export interface operations {
                      */
                     expiresAt?: string;
                     /** @description Additional metadata associated with the incoming payment. (Optional) */
-                    metadata?: Record<string, never>;
+                    metadata?: {
+                        [key: string]: unknown;
+                    };
                 };
             };
         };


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

- Add `additionalProperties: true` in incoming payment creation request body to allow proper type generation in the client

https://github.com/interledger/open-payments/pull/567#discussion_r2024473497
<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

Related to #249 