### PR TITLE
docs: style guide alignment

### DIFF
--- a/docs/src/content/docs/introduction/client-keys.mdx
+++ b/docs/src/content/docs/introduction/client-keys.mdx
@@ -120,24 +120,25 @@ This diagram shows the sequence of calls needed between a client and the servers
 {/* prettier-ignore */}
 <Mermaid
   graph={`sequenceDiagram
-participant C as Client
-participant AS as Authorization server
-participant RS as Resource server
-C->>C: 1.) Generates public/private key pair,<br>adds the public key to its key registry
-C->RS: Public key uploaded/accessible at the RS
-C->>AS: 2.) Requests an interactive outgoing-payment<br>grant (POST /), signs request with private key
-AS->>AS: 3.) Pulls keyId from grant request's signature-input<br>header, gets client's domain from request's body
-AS->>RS: 4.) Requests public keys from client's JWKS endpoint<br>GET {client_domain/jwks.json}
-RS-->>AS: 5.) 200 domain found,<br>returns public key
-AS->>AS: 6.) Uses public key to validate the signature in the client's<br>original request, binds client's domain to the grant
-AS-->>C: 7.) 200 OK
-note over AS: Explicit consent is collected from the client's user, facilitated by the client, authorization server, and IdP (not shown)
-C->>AS: 8.) Makes grant continuation request<br>(POST /continue) signed with private key
-AS->>AS: 9.) Pulls the keyId from the grant request's<br> signature-input header, gets client's domain<br>from the database entry for the grant
-AS->>RS: 10.) Requests public key bound to the domain from client's<br>JWKS endpoint GET {client_domain/jwks.json}
-RS-->>AS: 11.) 200 domain found,<br>returns public key
-AS->>AS: 12.) Finds the registry key with the matching<br> keyId, validates signature with key
-AS-->>C: 13.) 200 success,<br>access token issued,<br>grant continuation request complete
+    autonumber
+    participant C as Client
+    participant AS as Authorization server
+    participant RS as Resource server
+    C->>C: Generates public/private key pair,<br/>adds the public key to its key registry
+    C->RS: Public key uploaded to the resource server
+    C->>AS: POST grant request (interactive outgoing-payment), <br/>signed with private key
+    AS->>AS: Pulls keyId from grant request's signature-input <br/>header, gets client's domain from request's body
+    AS->>RS: GET {client_domain/jwks.json} public keys<br/> from client's JWKS endpoint
+    RS-->>AS: 200 JWKS document found, <br/>returns public key
+    AS->>AS: Validates the signature in the client's original request <br/>using the public key, binds client's domain to the grant
+    AS-->>C: 200 OK
+    note over AS: Explicit consent is collected from the client's user, facilitated by the client, authorization server, and IdP (not shown)
+    C->>AS: POST grant continuation request, <br/>signed with private key
+    AS->>AS: Pulls the keyId from the grant request's <br/>signature-input header, gets client's domain <br/>from the database entry for the grant
+    AS->>RS: GET {client_domain/jwks.json} public key bound <br/>to the domain from client's JWKS endpoint
+    RS-->>AS: 200 JWKS document found, <br/>returns public key
+    AS->>AS: Validates signature with the <br/>key found in the registry
+    AS-->>C: 200 success, access token issued, <br/>grant continuation request complete
 `}
 />
 

--- a/docs/src/content/docs/introduction/op-flow.mdx
+++ b/docs/src/content/docs/introduction/op-flow.mdx
@@ -32,8 +32,8 @@ A client retrieves public details about a recipient's Open Payments-enabled acco
     participant C as Client
     participant WA as Wallet address
 
-    C->>WA: GET wallet address url (e.g. https://wallet.example.com/alice)
-    WA->>C: 200 wallet address found, return public account details
+    C->>WA: GET wallet address URL (e.g. https://wallet.example.com/alice)
+    WA-->>C: 200 wallet address found, return public account details
 
 `}
 />
@@ -52,10 +52,10 @@ The client first <LinkOut href='/apis/auth-server/operations/post-request'>reque
     participant AS as Authorization server<br/>recipient's ASE
     participant RS as Resource server<br/>recipient's ASE
 
-    C->>AS: Grant request (POST) with type=incoming-payment
-    AS->>C: 200 OK, returns access token
-    C->>RS: Create incoming payment resource (POST)
-    RS->>C: 201 Incoming payment resource created
+    C->>AS: POST grant request with type=incoming-payment
+    AS-->>C: 200 OK, returns access token
+    C->>RS: POST create incoming payment
+    RS-->>C: 201 incoming payment created, return incoming payment with public details
 
 `}
 />
@@ -74,10 +74,10 @@ The client <LinkOut href='/apis/auth-server/operations/post-request'>requests/re
     participant AS as Authorization server<br/>sender's ASE
     participant RS as Resource server<br/>sender's ASE
 
-    C->>AS: Grant request (POST) with type=quote
-    AS->>C: 200 OK, returns access token
-    C->>RS: Create quote resource (POST)
-    RS->>C: 201 Quote resource created
+    C->>AS: POST grant request with type=quote
+    AS-->>C: 200 OK, returns access token
+    C->>RS: POST create quote
+    RS-->>C: 201 quote created, returns quote details
 
 `}
 />
@@ -108,8 +108,8 @@ Once an access token is acquired, the client can request the creation of the <Li
     participant C as Client
     participant RS as Resource server<br/>sender's ASE
 
-    C->>RS: Create outgoing payment resource (POST)
-    RS->>C: 201 Outgoing payment resource created
+    C->>RS: POST create outgoing payment
+    RS-->>C: 201 outgoing payment created, <br/>returns outgoing payment details
 
 `}
 />
@@ -128,8 +128,8 @@ To provide a user with their transaction history, the client can retrieve a list
     participant C as Client
     participant RS as Resource server
 
-    C->>RS: Get list of incoming/outgoing payments <br/>with wallet-address={url of wallet address}
-    RS->>C: 200 OK
+    C->>RS: GET list of incoming/outgoing payments <br/>with wallet-address={URL of wallet address}
+    RS-->>C: 200 OK, returns array of incoming/outgoing payments <br/>with relevant payment details
 
 `}
 />
@@ -146,8 +146,8 @@ Similarly, the client can provide the user with details about a specific <LinkOu
     participant C as Client
     participant RS as Resource server
 
-    C->>RS: Get incoming/outgoing payment with <br/>id={url identifying incoming/outgoing payment}
-    RS->>C: 200 Payment found
+    C->>RS: GET an incoming/outgoing payment with <br/>id={URL identifying incoming/outgoing payment}
+    RS-->>C: 200 incoming/outgoing payment found, <br/>returns incoming/outgoing payment details
 
 `}
 />
@@ -178,38 +178,38 @@ More information about grant interaction flows can be found in the [Grant negoti
     participant RAS as Auth server
     participant RRS as Resource server
     end
-    SC->>+RW: Sends GET request
-    RW->>-SC: Responds with auth & resource server URLs
-    SC->>+RAS: Sends a non-interactive grant request<br/>(type=incoming-payment)
-    RAS->>-SC: Responds with access token & grant
-    SC->>+RRS: Sends request to create an incoming payment resource
-    RRS->>RAS: Requests validation of access token
-    RAS->>RRS: Access token is validated
-    RRS->>-SC: Incoming payment resource is created
-    SC->>+SAS: Sends non-interactive grant request<br/>(type=quote)
-    SAS->>-SC: Responds with access token and grant
-    SC->>+SRS: Sends request to create a quote resource
-    SRS->>-SC: Quote resource is created
-    SC->>+SAS: Sends interactive grant request<br/>(type=outgoing-payment)
-    SAS->>-SC: Responds with interact redirect uri and continue uri
-    SC->>+SAS: Navigates to interact redirect uri
-    SAS->>SAS: Starts interaction<br/>and sets session
-    SAS->>-SC: Responds with identity provider uri
+    SC->>+RW: Requests the wallet address
+    RW-->>-SC: Provides the wallet address details
+    SC->>+RAS: Requests a non-interactive grant for an incoming payment
+    RAS-->>-SC: Provides access token and grant for the payment
+    SC->>+RRS: Request to create the incoming payment
+    RRS->>+RAS: Requests access token validation
+    RAS-->>-RRS: Access token is validated
+    RRS-->>-SC: Incoming payment is created
+    SC->>+SAS: Requests a non-interactive grant for a quote
+    SAS-->>-SC: Provides access token and grant for the quote
+    SC->>+SRS: Request to create the quote
+    SRS-->>-SC: Quote is created
+    SC->>+SAS: Requests an interactive grant for an outgoing payment
+    SAS-->>-SC: Provides interact redirect URI and continue URI
+    SC->>+SAS: Navigates to the interact redirect URI
+    SAS->>SAS: Starts the interaction process and sets up the session
+    SAS-->>-SC: Provides identity provider URI
     SC->>+SIDP: Navigates (redirects) to identity provider
-    SIDP->>SIDP: Sender accepts interaction,<br/>for eg: confirms payment intent
+    SIDP->>SIDP: Sender accepts interaction, <br/>confirms payment intent
     SIDP->>SAS: Sends interaction choice
-    SAS->>SIDP: Accepts choice
-    SIDP->>SAS: Requests to finish interaction
-    SAS->>SAS: Ends session
-    SAS->>SIDP: Redirects to finish url defined in initial grant request
+    SAS->>SIDP: Confirms the choice has been accepted
+    SIDP->>SAS: Requests to finalize the interaction
+    SAS->>SAS: Completes the session
+    SAS->>SIDP: Redirects to interact URI defined in initial grant request
     SIDP->>-SC: Follows redirect
     SC->>SC: Verifies hash
-    SC->>+SAS: Sends a grant continuation request
-    SAS->>-SC: Responds with a grant access token
-    SC->>+SRS: Sends request to create an outgoing payment resource
-    SRS->>SAS: Requests validation of access token
+    SC->>+SAS: Requests a grant continuation
+    SAS->>-SC: Provides a grant access token
+    SC->>+SRS: Request to create the outgoing payment
+    SRS->>SAS: Requests access token validation
     SAS->>SRS: Access token is validated
-    SRS->>-SC: Outgoing payment resource is created
+    SRS->>-SC: Outgoing payment is created
 `}
 />
 

--- a/docs/src/partials/diagram-interactive-grant.mdx
+++ b/docs/src/partials/diagram-interactive-grant.mdx
@@ -5,22 +5,22 @@ import { MermaidWrapper, Mermaid } from '@interledger/docs-design-system'
 {/* prettier-ignore */}
 <Mermaid
   graph={`sequenceDiagram autonumber
-    Client ->>Authorization server (AS): Sends interactive grant request
-    Authorization server (AS)-->>Client: 200 returns interact redirect uri and continue uri
-    Client ->>Authorization server (AS): Navigates to interact redirect uri
+    Client->>Authorization server (AS): POST grant request (with interact object)
+    Authorization server (AS)-->>Client: 200 OK, returns interact redirect URI and continue URI
+    Client->>Authorization server (AS): Navigates to interact redirect URI
     Authorization server (AS)->>Authorization server (AS): Starts interaction and sets session
-    Authorization server (AS)-->>Client: 302 temporary redirect to identity provider <br>uri with grant info in query string
-    Client ->>Identity provider (IdP): Redirects to identity provider
+    Authorization server (AS)-->>Client: 302 temporary redirect to identity provider <br>URI with grant info in query string
+    Client->>Identity provider (IdP): Redirects to identity provider
     Identity provider (IdP)->>Identity provider (IdP): Resource owner (e.g. client user) <br>accepts interaction
     Identity provider (IdP)->>Authorization server (AS): Sends interaction choice
-    Authorization server (AS) -->>Identity provider (IdP): 202 choice accepted
+    Authorization server (AS)-->>Identity provider (IdP): 202 choice accepted
     Identity provider (IdP)->>Authorization server (AS): Requests to finish interaction
     Authorization server (AS)->>Authorization server (AS): Ends session
-    Authorization server (AS)-->>Identity provider (IdP): 302 temporary redirect to finish url <br>(defined in initial grant request) <br>secured with unique hash and <br>interact_ref in query string
+    Authorization server (AS)-->>Identity provider (IdP): 302 temporary redirect to finish URI <br>(defined in initial grant request) <br>secured with unique hash and <br>interact_ref in query string
     Identity provider (IdP)->>Client instance: Follows redirect
     Client->>Client: Verifies hash
-    Client->>Authorization server (AS): Sends grant continuation request with <br>interact_ref in body to continue uri
-    Authorization server (AS)->>Client: 200 returns grant access token
+    Client->>Authorization server (AS): POST grant continuation request with <br>interact_ref in body to continue URI
+    Authorization server (AS)-->>Client: 200 OK, returns grant access token
 `}
 />
 


### PR DESCRIPTION
Updated sequence diagrams to align with style guide

Slight alterations to the full flow diagram on the Open Payments flow page:

- Removed technical details and made it more functional
- Changed "redirects to finish URI" to "redirects to interact URI" (`finish` is a string used as a key, not a URI)

Fixes https://github.com/interledger/open-payments/issues/587