### PR TITLE
fix: add support for php code snippets

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -16,10 +16,11 @@
     "mermaid": "^11.6.0",
     "sharp": "^0.34.1",
     "shiki": "3.2.1",
-    "starlight-openapi": "^0.14.4",
-    "starlight-links-validator": "^0.15.0"
+    "starlight-links-validator": "^0.15.0",
+    "starlight-openapi": "^0.14.4"
   },
   "devDependencies": {
+    "@prettier/plugin-php": "^0.22.4",
     "prettier": "3.5.3"
   }
 }

--- a/docs/src/components/ChunkedSnippet.astro
+++ b/docs/src/components/ChunkedSnippet.astro
@@ -3,6 +3,7 @@ import prettier from 'prettier';
 import { Code } from 'astro:components';
 import { CodeBlock } from '@interledger/docs-design-system'
 const {source, chunk} = Astro.props;
+import * as phpPlugin from '@prettier/plugin-php'
 
 // Retrieve code snippet from GitHub as text
 const getApiData = async () => {
@@ -67,16 +68,64 @@ for (const delimiter of delimiterArray) {
 
 // Handle zero-index situation and format code nicely
 const chunkNumber = parseInt(chunk) - 1;
-const rawOutput = codeChunkArray[chunkNumber].code_chunk;
-const output = await prettier.format(rawOutput, {
-  parser: 'typescript',
-  tabWidth: 2,
-});
-const codeBlockTitle = codeChunkArray[chunkNumber].title;
+let rawOutput = codeChunkArray[chunkNumber]?.code_chunk;
+interface LanguageConfig {
+  parser: string;
+  lang: string;
+  plugins: any[];
+};
+
+const languageConfig: Record<string, LanguageConfig> = {
+  '.php': {
+    parser: 'php',
+    lang: 'php',
+    plugins: [phpPlugin]
+  },
+  '.ts': {
+    parser: 'typescript',
+    lang: 'ts',
+    plugins: []
+  }
+};
+
+const getLanguageConfig = (url: string): LanguageConfig | null => {
+  const ext = Object.keys(languageConfig).find((key) => url.endsWith(key))
+  return ext
+    ? languageConfig[ext]
+    : null
+};
+
+const { parser, lang, plugins } = getLanguageConfig(source) ?? {
+  parser: '',
+  lang: '',
+  plugins: [],
+};
+
+let output
+if (!parser || !lang || !rawOutput) {
+  output = 'Code snippet not found.'
+} else {
+  if (lang === 'php') {
+    // The PHP Prettier plugin requires the <?php opening delimiter for formatting
+    rawOutput = rawOutput.trim().startsWith('<?php')
+      ? rawOutput
+      : `<?php\n${rawOutput}`
+  }
+  output = await prettier.format(rawOutput, {
+    parser,
+    tabWidth: 2,
+    plugins
+  })
+  if (lang === 'php') {
+    output = output.replace(/^<\?php\s*/, '')
+  }
+};
+
+const codeBlockTitle = codeChunkArray[chunkNumber]?.title;
 ---
 
-<CodeBlock title={codeBlockTitle} class="chunked-snippet">
-  <Code code={output} lang="ts" theme="css-variables" />
+<CodeBlock title={codeBlockTitle} class='chunked-snippet'>
+  <Code code={output} lang={lang} theme='css-variables' />
   <span>Copied!</span>
   <button data-copy-button type="button">
     <svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke-width='1.75'>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
         specifier: ^0.14.4
         version: 0.14.4(@astrojs/markdown-remark@6.3.1)(@astrojs/starlight@0.33.0)(astro@5.6.1)(openapi-types@12.1.3)
     devDependencies:
+      '@prettier/plugin-php':
+        specifier: ^0.22.4
+        version: 0.22.4(prettier@3.5.3)
       prettier:
         specifier: 3.5.3
         version: 3.5.3
@@ -1283,14 +1286,6 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@emnapi/runtime@1.3.1:
-    resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
-    requiresBuild: true
-    dependencies:
-      tslib: 2.8.1
-    dev: false
-    optional: true
-
   /@emnapi/runtime@1.4.0:
     resolution: {integrity: sha512-64WYIf4UYcdLnbKn/umDlNjQDSS8AgZrI/R9+x5ilkUVFxXcA1Ebl+gQLc/6mERA4407Xof0R7wEyEuj091CVw==}
     requiresBuild: true
@@ -1957,7 +1952,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.3.1
+      '@emnapi/runtime': 1.4.0
     dev: false
     optional: true
 
@@ -2454,6 +2449,16 @@ packages:
     requiresBuild: true
     dev: false
     optional: true
+
+  /@prettier/plugin-php@0.22.4(prettier@3.5.3):
+    resolution: {integrity: sha512-uZWqfyrwsxScIYkmVcfnoQGFmKVMXTHD5pqYT4l8fxzm5P3XY94hTPbf8X6TFCi2QTZBIot7GS8lfIjQjldc2g==}
+    peerDependencies:
+      prettier: ^3.0.0
+    dependencies:
+      linguist-languages: 7.30.0
+      php-parser: 3.2.3
+      prettier: 3.5.3
+    dev: true
 
   /@readme/better-ajv-errors@1.6.0(ajv@8.12.0):
     resolution: {integrity: sha512-9gO9rld84Jgu13kcbKRU+WHseNhaVt76wYMeRDGsUGYxwJtI3RmEJ9LY9dZCYQGI8eUZLuxb5qDja0nqklpFjQ==}
@@ -7405,6 +7410,10 @@ packages:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
     dev: true
 
+  /linguist-languages@7.30.0:
+    resolution: {integrity: sha512-/mR2Ip16dSeYlYm9ekRLIQWy2b9IiTYuwsBbqZX7FF0Vkmg5myT8ALwHHxt5kTadHziegAAda+i4zEJxR5NdNw==}
+    dev: true
+
   /load-yaml-file@0.2.0:
     resolution: {integrity: sha512-OfCBkGEw4nN6JLtgRidPX6QxjBQGQf72q3si2uvqyFEMbycSFFHwAZeXx6cJgFM9wmLrf9zBwCP3Ivqa+LLZPw==}
     engines: {node: '>=6'}
@@ -8757,6 +8766,10 @@ packages:
   /pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
     dev: false
+
+  /php-parser@3.2.3:
+    resolution: {integrity: sha512-Kyu33y36aRed6HUi7ZS8EDG9/ZBz4lx/cJgoQui1B/x0L0ZCbCiBstdGnlGgufk8YwcLsk4J9VK9auXoL4Jz8A==}
+    dev: true
 
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Adds a PHP Prettier plugin to format PHP code snippets and add in PHP code snippet support.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

fixes #594
