### PR TITLE
chore: update client usage in readme & docs

### DIFF
--- a/.changeset/beige-grapes-brush.md
+++ b/.changeset/beige-grapes-brush.md
@@ -1,0 +1,5 @@
+---
+'@interledger/open-payments': patch
+---
+
+Updated example usage of client in the README

--- a/docs/src/content/docs/guides/split-payments.mdx
+++ b/docs/src/content/docs/guides/split-payments.mdx
@@ -80,7 +80,7 @@ If you and the merchant use the same account servicing entity, and the authoriza
 <Tabs>
 <TabItem label = 'Merchant'>
 ```ts wrap
-const merchantGrant = await client.grant.request(
+const merchantIncomingPaymentGrant = await client.grant.request(
   {
     url: merchantWalletAddress.authServer,
   },
@@ -99,7 +99,7 @@ const merchantGrant = await client.grant.request(
 </TabItem>
 <TabItem label = 'Platform'>
 ```ts wrap
-const platformGrant = await client.grant.request(
+const platformIncomingPaymentGrant = await client.grant.request(
   {
     url: platformWalletAddress.authServer,
   },
@@ -130,11 +130,11 @@ In this example, you will give the merchant 99% of the payment while retaining 1
 ```ts wrap
 const merchantIncomingPayment = await client.incomingPayment.create(
   {
-    url: new URL(WALLET_ADDRESS).origin,
-    accessToken: INCOMING_PAYMENT_ACCESS_TOKEN
+    url: merchantWalletAddress.resourceServer,
+    accessToken: merchantIncomingPaymentGrant.access_token.value
   },
   {
-    walletAddress: MERCHANT_WALLET_ADDRESS,
+    walletAddress: merchantWalletAddress.id,
     incomingAmount: {
       value: '9900',
       assetCode: 'USD',
@@ -152,11 +152,11 @@ const merchantIncomingPayment = await client.incomingPayment.create(
 ```ts wrap
 const platformIncomingPayment = await client.incomingPayment.create(
   {
-    url: new URL(WALLET_ADDRESS).origin,
-    accessToken: INCOMING_PAYMENT_ACCESS_TOKEN
+    url: platformWalletAddress.resourceServier,
+    accessToken: platformIncomingPaymentGrant.access_token.value
   },
   {
-    walletAddress: PLATFORM_WALLET_ADDRESS,
+    walletAddress: platformWalletAddress.id,
     incomingAmount: {
       value: '100',
       assetCode: 'USD',
@@ -175,7 +175,7 @@ const platformIncomingPayment = await client.incomingPayment.create(
 Request a `quote` grant from the customer wallet authorization server. You received the authorization server URL as part of Step 1.
 
 ```ts wrap
-const customerGrant = await client.grant.request(
+const customerQuoteGrant = await client.grant.request(
   {
     url: customerWalletAddress.authServer
   },
@@ -196,20 +196,18 @@ const customerGrant = await client.grant.request(
 
 Using the customer-side access token received from the previous step, request the creation of two `quote` resources: one on the merchant wallet account and one on your platform wallet account.
 
-Each request should contain its respective `INCOMING_PAYMENT_URL` received from Step 3.
-
 <Tabs>
 <TabItem label = 'Merchant'>
 ```ts wrap
 const merchantQuote = await client.quote.create(
   {
-    url: new URL(WALLET_ADDRESS).origin,
-    accessToken: QUOTE_ACCESS_TOKEN
+    url: customerWalletAddress.resourceServer,
+    accessToken: customerQuoteGrant.access_token.value
   },
   {
     method: 'ilp',
-    walletAddress: WALLET_ADDRESS,
-    receiver: INCOMING_PAYMENT_URL
+    walletAddress: customerWalletAddress.id,
+    receiver: merchantIncomingPayment.id
   }
 )
 ```
@@ -218,13 +216,13 @@ const merchantQuote = await client.quote.create(
 ```ts wrap
 const platformQuote = await client.quote.create(
   {
-    url: new URL(WALLET_ADDRESS).origin,
-    accessToken: QUOTE_ACCESS_TOKEN
+    url: customerWalletAddress.resourceServer,
+    accessToken: customerQuoteGrant.access_token.value
   },
   {
     method: 'ilp',
-    walletAddress: WALLET_ADDRESS,
-    receiver: INCOMING_PAYMENT_URL
+    walletAddress: customerWalletAddress.id,
+    receiver: platformIncomingPayment.id
   }
 )
 ```
@@ -242,7 +240,7 @@ Outgoing payments require an interactive grant. This type of grant will obtain t
 Include the `receiveAmount` object within the `limits` object. The `value` property must be the total amount the customer has agreed to pay.
 
 ```ts wrap
-const customerGrant = await client.grant.request(
+const pendingCustomerOutgoingPaymentGrant = await client.grant.request(
   {
     url: customerWalletAddress.authServer
   },
@@ -296,10 +294,10 @@ In a scenario where a user interface is not available, consider implementing a p
 Add the `interact_ref` returned by the client wallet authorization server in the previous step.
 
 ```ts wrap
-const customerGrant = await client.grant.continue(
+const customerOutgoingPaymentGrant = await client.grant.continue(
   {
-    accessToken: CONTINUE_ACCESS_TOKEN,
-    url: CONTINUE_URI
+    url: pendingCustomerOutgoingPaymentGrant.continue.uri,
+    accessToken: pendingCustomerOutgoingPaymentGrant.continue.access_token.value
   },
   {
     interact_ref: interactRef
@@ -358,7 +356,7 @@ The `quoteId` is the URL of the quote that specified the amount to be paid to th
 const customerOutgoingPayment = await client.outgoingPayment.create(
   {
     url: customerWalletAddress.resourceServer,
-    accessToken: OUTGOING_PAYMENT_ACCESS_TOKEN
+    accessToken: customerOutgoingPaymentGrant.access_token.value
   },
   {
     walletAddress: customerWalletAddress.id,
@@ -374,8 +372,8 @@ const customerOutgoingPayment = await client.outgoingPayment.create(
 ```ts wrap
 const customerOutgoingPayment = await client.outgoingPayment.create(
   {
-    url: new URL(WALLET_ADDRESS).origin,
-    accessToken: OUTGOING_PAYMENT_ACCESS_TOKEN
+    url: customerWalletAddress.resourceServer,
+    accessToken: customerOutgoingPaymentGrant.access_token.value
   },
   {
     walletAddress: customerWalletAddress.id,

--- a/docs/src/content/docs/guides/split-payments.mdx
+++ b/docs/src/content/docs/guides/split-payments.mdx
@@ -82,7 +82,7 @@ If you and the merchant use the same account servicing entity, and the authoriza
 ```ts wrap
 const merchantIncomingPaymentGrant = await client.grant.request(
   {
-    url: merchantWalletAddress.authServer,
+    url: merchantWalletAddress.authServer
   },
   {
     access_token: {
@@ -101,7 +101,7 @@ const merchantIncomingPaymentGrant = await client.grant.request(
 ```ts wrap
 const platformIncomingPaymentGrant = await client.grant.request(
   {
-    url: platformWalletAddress.authServer,
+    url: platformWalletAddress.authServer
   },
   {
     access_token: {
@@ -152,7 +152,7 @@ const merchantIncomingPayment = await client.incomingPayment.create(
 ```ts wrap
 const platformIncomingPayment = await client.incomingPayment.create(
   {
-    url: platformWalletAddress.resourceServier,
+    url: platformWalletAddress.resourceServer,
     accessToken: platformIncomingPaymentGrant.access_token.value
   },
   {

--- a/packages/open-payments/README.md
+++ b/packages/open-payments/README.md
@@ -108,6 +108,7 @@ try {
     console.log(error.status) // the HTTP status of the request, if a request failure
     console.log(error.code) // the error code from the Open Payments API
     console.log(error.validationErrors) // an array of validation errors. Populated if the response of the request failed OpenAPI specfication validation, or other validation checks.
+    console.log(error.details) // an object containing additional error details
   } else {
     console.log(error)
   }
@@ -135,7 +136,7 @@ const client = await createAuthenticatedClient({
   walletAddressUrl: 'https://online-marketplace.com/usa',
   keyId: KEY_ID,
   privateKey: PRIVATE_KEY
-  // The public JWK with this key (and keyId) would be available at https://online-marketplace.com/usa/jwks.json
+  // The public JWK with this key (and keyId) must be available at https://online-marketplace.com/usa/jwks.json
 })
 ```
 
@@ -178,7 +179,7 @@ and creates an `IncomingPayment` using the access token from the grant:
 ```ts
 const incomingPayment = await client.incomingPayment.create(
   {
-    url: new URL(shoeShopWalletAddress.id).origin,
+    url: shoeShopWalletAddress.resourceServer,
     accessToken: incomingPaymentGrant.access_token.value
   },
   {
@@ -217,7 +218,7 @@ const quoteGrant = await client.grant.request(
 
 const quote = await client.quote.create(
   {
-    url: new URL(customerWalletAddress.id).origin,
+    url: customerWalletAddress.resourceServer,
     accessToken: quoteGrant.access_token.value
   },
   {
@@ -245,8 +246,7 @@ const outgoingPaymentGrant = await client.grant.request(
           actions: ['read', 'create', 'list'],
           identifier: customerWalletAddress.id,
           limits: {
-            debitAmount: quote.debitAmount, // to authorize an amount up to the quoted amount
-            receiveAmount: quote.receiveAmount
+            debitAmount: quote.debitAmount // to authorize an amount up to the quoted amount
           }
         }
       ]
@@ -293,8 +293,8 @@ Once Alice approves the grant request at Cloud Nine Wallet (or the Identity Prov
 ```ts
 const finalizedOutgoingPaymentGrant = await client.grant.continue(
   {
-    accessToken: outgoingPaymentGrant.access_token.value,
-    url: outgoingPaymentGrant.continue.uri
+    url: outgoingPaymentGrant.continue.uri,
+    accessToken: outgoingPaymentGrant.continue.access_token.value
   },
   { interact_ref: INTERACT_REF_FROM_URL }
 )
@@ -307,7 +307,7 @@ Once the grant interaction flow has finished, and Alice has consented to the pay
 ```ts
 const outgoingPayment = await client.outgoingPayment.create(
   {
-    url: new URL(customerWalletAddress.id).origin,
+    url: customerWalletAddress.resourceServer,
     accessToken: finalizedOutgoingPaymentGrant.access_token.value
   },
   {


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request
- Updating client README to
   - Replacing `new URL(customerWalletAddress.id).origin` to use eg. `customerWalletAddress.resourceServer` directly
   - Making sure we are not providing both `receiveAmount` and `debitAmount` in the same grant outgoing payment request, as that is no longer possible
- Updating split payments doc
    - use customerWalletAddress.resourceServer directly instead of e.g. URL(customerWalletAddress.id).origin
    - updating variable names to be more clear about what is used where

<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
Fixes #615 