### PR TITLE
docs: differentiate API and SDK content

### DIFF
--- a/docs/src/content/docs/overview/getting-started.mdx
+++ b/docs/src/content/docs/overview/getting-started.mdx
@@ -6,11 +6,13 @@ import { LinkOut } from '@interledger/docs-design-system'
 
 :::tip[Summary]
 Open Payments is an API standard for banks, mobile money providers, and other account servicing entities. It allows developers to build payment capabilities into their apps without the need for custom integrations or third-party payment processors.
+
+Developers can choose to interact with the Open Payments API directly or use the provided SDKs for a more streamlined integration experience.
 :::
 
 Handling payments is a crucial part of many online applications. Whether it's an eCommerce site selling products, a fundraising platform accepting donations, a streaming service charging for content, or a subscription service with monthly fees, digital payments are central to their operations. Many application developers rely on third-party payment gateways to handle these transactions, which can introduce additional expenses and limit control over the user experience.
 
-Open Payments is an open RESTful API and an API standard that enables clients to interface with Open Payments-enabled accounts. In this context, a client is an application, such as a mobile or web app, that consumes one or more Open Payments resources, typically requiring access privileges from one or several authorization servers.
+Open Payments is an open RESTful API and an API standard that enables clients to interface with Open Payments-enabled accounts. In this context, a client is an application, such as a mobile or web app, that consumes one or more Open Payments resources, typically requiring access privileges from one or several authorization servers. The [Open Payments SDKs](/sdk/before-you-begin) simplify this process by providing pre-built functions for these interactions.
 
 The Open Payments standard is meant to be implemented by account servicing entities (ASEs). ASEs provide and maintain payment accounts for senders and recipients, and are regulated entities within the countries they operate. Examples of ASEs include banks, digital wallet providers, and mobile money providers.
 

--- a/docs/src/content/docs/resources/glossary.mdx
+++ b/docs/src/content/docs/resources/glossary.mdx
@@ -26,7 +26,7 @@ An [incoming payment resource](/concepts/resources/#incoming-payment) is an obje
 
 ## Open Payments (OP)
 
-Open Payments is an open RESTful API and an API standard that enables clients to interface with Open Payments-enabled accounts.
+Open Payments is an open RESTful API and an API standard that enables clients to interface with Open Payments-enabled accounts. Developers can choose to interact with the Open Payments API directly or use the [Open Payments SDKs](/sdk/before-you-begin) for a more streamlined integration experience.
 
 ## Outgoing payment resource
 

--- a/docs/src/content/docs/sdk/before-you-begin.mdx
+++ b/docs/src/content/docs/sdk/before-you-begin.mdx
@@ -1,14 +1,34 @@
 ---
-title: Test Wallet
+title: Before you begin
 ---
 
 import { LinkOut } from '@interledger/docs-design-system'
 
-Before working with our code snippets, we recommend creating a wallet account on the <LinkOut href='https://wallet.interledger-test.dev/'>test wallet</LinkOut> that's part of the Interledger testnet.
+The Open Payments SDKs provide developers with pre-built functions that simplify interactions with the Open Payments API. Currently, we offer a <LinkOut href='https://github.com/interledger/open-payments/tree/main/packages/open-payments'>TypeScript/NodeJS SDK</LinkOut> and a <LinkOut href='https://github.com/interledger/open-payments-php'>PHP SDK</LinkOut>, with plans to expand to additional languages and frameworks in the future.
 
-The test wallet lets you create developer keys and wallet accounts, funded with play money, for making Interledger transactions via the Open Payments APIs.
+## Using the SDKs
+
+Each SDK snippet page uses a tabbed interface to support multiple programming languages. This means you can find the relevant code snippets for the language of your choice with ease, without needing individual pages for each language. The basic structure of each page is as follows:
+
+- The page title reflects the operation, function, or action being performed.
+- A few overview paragraphs provide context about the function, its role in the Open Payments flow, and any general information that may be helpful.
+- The "Before you begin" section that links back to this page for steps to create a test wallet.
+- The main content area includes the tabbed interface where you can select your preferred programming language.
+
+Within the tabbed interface, you'll notice the following sections:
+
+- A "Prerequisites" button that links to the respective SDK's README on GitHub for setup instructions.
+- Any additional configuration steps required for the selected language.
+- Code blocks for each step in the process, broken down into manageable chunks.
+- After the code snippets, any other commands that need to be run are mentioned, along with links to the relevant API reference documentation or other pertinent resources.
+
+This consistent structure across all SDK snippet pages allow you to quickly grasp the functionality and implementation details, making it easier to work with the Open Payments SDKs.
 
 ## Create an account on the test wallet
+
+Before working with our SDK snippets, we recommend creating a wallet account on the <LinkOut href='https://wallet.interledger-test.dev/'>test wallet</LinkOut> that's part of the Interledger testnet.
+
+The test wallet lets you create developer keys and wallet accounts, funded with play money, for making Interledger transactions via the Open Payments APIs.
 
 1. Go to <LinkOut href="https://wallet.interledger-test.dev">wallet.interledger-test.dev</LinkOut>.
 2. Click **Create account** at the bottom-right of the screen.

--- a/docs/src/partials/before-you-begin.mdx
+++ b/docs/src/partials/before-you-begin.mdx
@@ -1,1 +1,1 @@
-We recommend creating a wallet account on the [test wallet](/sdk/before-you-begin). Creating an account allows you to test your client against the Open Payments APIs by using an ILP-enabled wallet funded with play money.
+We recommend creating a wallet account on the [test wallet](/sdk/before-you-begin#create-an-account-on-the-test-wallet). Creating an account allows you to test your client against the Open Payments APIs by using an ILP-enabled wallet funded with play money.


### PR DESCRIPTION
- Revised "Getting Started" to introduce the OP SDKs and clarify their role
- Renamed "Test Wallet" title to "Before you begin" to match the left nav
- Updated "Before you Begin" content to introduce the SDKs and how to use the SDK snippet pages, including the consistent page structure across snippets
- Update link in "Before you Begin" partial to the test wallet section
- Updated "Open Payments (OP)" term in the Glossary to include a brief mention of the SDKs

Fixes [OP 613](https://github.com/interledger/open-payments/issues/613)