### PR TITLE
add badge to new guide

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -262,7 +262,8 @@ export default defineConfig({
             },
             {
               label: 'Get an outgoing payment grant for future payments',
-              link: '/guides/outgoing-grant-future-payments/'
+              link: '/guides/outgoing-grant-future-payments/',
+              badge: 'New'
             }
           ]
         },


### PR DESCRIPTION
Adds a New badge to the outgoing grant guide's listing in the sidenav.