### PR TITLE
feat: add language icons to tab labels

### DIFF
--- a/docs/src/content/docs/guides/outgoing-grant-future-payments.mdx
+++ b/docs/src/content/docs/guides/outgoing-grant-future-payments.mdx
@@ -48,7 +48,7 @@ Let’s assume your user saved their wallet address in their account profile whe
 You should perform this step every time you request a grant in case something changes on your user’s side.
 
 <Tabs syncKey="lang">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 ```ts
 const walletAddress = await client.walletAddress.get({
   url: 'https://cloudninebank.example.com/user'
@@ -74,7 +74,7 @@ The request must include:
 - `interact` object with a `finish` URI - The URI your user will be automatically sent to when interaction, described in the next steps, is complete.
 
 <Tabs syncKey="lang">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 ```ts
 const grant = await client.grant.request(
   {
@@ -141,7 +141,7 @@ Altogether, your user can send up to $100 CAD from:
 Use the interaction reference (`interact_ref`) returned in the redirect URI's query parameters.
 
 <Tabs syncKey='lang'>
-  <TabItem label='TypeScript/JavaScript'>
+  <TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
     <ChunkedSnippet
       source='https://raw.githubusercontent.com/interledger/open-payments-snippets/main/grant/grant-continuation.ts'
       chunk='3'

--- a/docs/src/content/docs/sdk/grant-continue.mdx
+++ b/docs/src/content/docs/sdk/grant-continue.mdx
@@ -27,7 +27,7 @@ After the user completes their interaction with the identity provider (IdP), the
 ## Issue grant continuation request
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -57,7 +57,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-continuation.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/grant-create-incoming.mdx
+++ b/docs/src/content/docs/sdk/grant-create-incoming.mdx
@@ -23,7 +23,7 @@ The snippets below enable a client to request a grant for an incoming payment. T
 ## Request an incoming payment grant
 
 <Tabs syncKey="langs">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -58,7 +58,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-incoming-payment.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/grant-create-outgoing.mdx
+++ b/docs/src/content/docs/sdk/grant-create-outgoing.mdx
@@ -27,7 +27,7 @@ In Open Payments, outgoing payments require explicit consent, usually by the cli
 Open Payments also requires any authorization server that issues interactive grants to integrate with an [identity provider (IdP)](/identity/idp). When the client requests the outgoing payment grant, the authorization server provides the client with the IdP URI the client should redirect to.
 
 <Tabs syncKey="langs">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -71,7 +71,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-outgoing-payment.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/grant-create-quote.mdx
+++ b/docs/src/content/docs/sdk/grant-create-quote.mdx
@@ -23,7 +23,7 @@ The snippets below enable a client to request a grant for a quote. The request t
 ## Request a quote grant
 
 <Tabs syncKey="langs">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -58,7 +58,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-quote.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/grant-revoke.mdx
+++ b/docs/src/content/docs/sdk/grant-revoke.mdx
@@ -21,7 +21,7 @@ These code snippets enable a client to revoke (cancel) a grant that it was previ
 ## Revoke a grant request
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -41,7 +41,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/grant/grant-revoke.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/incoming-complete.mdx
+++ b/docs/src/content/docs/sdk/incoming-complete.mdx
@@ -21,7 +21,7 @@ These code snippets pass the wallet address and incoming payment URL to the reso
 ## Mark an incoming payment as complete
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -46,7 +46,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/incoming-payment/incoming-payment-complete.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/incoming-create.mdx
+++ b/docs/src/content/docs/sdk/incoming-create.mdx
@@ -21,7 +21,7 @@ These code snippets create an incoming payment of $10 USD at a given wallet addr
 ## Create an incoming payment resource
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -46,7 +46,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/incoming-payment/incoming-payment-create.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/incoming-get.mdx
+++ b/docs/src/content/docs/sdk/incoming-get.mdx
@@ -23,7 +23,7 @@ These code snippets return the state and details of a specific incoming payment,
 ## Get the state of an incoming payment
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -57,7 +57,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/incoming-payment/incoming-payment-get.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/incoming-list.mdx
+++ b/docs/src/content/docs/sdk/incoming-list.mdx
@@ -21,7 +21,7 @@ These code snippets retrieve the first ten incoming payments on the given wallet
 ## List all incoming payments on a wallet address
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -46,7 +46,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/incoming-payment/incoming-payment-list.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/outgoing-create.mdx
+++ b/docs/src/content/docs/sdk/outgoing-create.mdx
@@ -23,7 +23,7 @@ These code snippets create an outgoing payment to a given wallet address. The am
 ## Create an outgoing payment resource
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -48,7 +48,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/outgoing-payment/outgoing-payment-create.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/outgoing-get.mdx
+++ b/docs/src/content/docs/sdk/outgoing-get.mdx
@@ -21,7 +21,7 @@ These code snippets return the state and details of a specific outgoing payment,
 ## Get the state of an outgoing payment
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -46,7 +46,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/outgoing-payment/outgoing-payment-get.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/outgoing-list.mdx
+++ b/docs/src/content/docs/sdk/outgoing-list.mdx
@@ -21,7 +21,7 @@ These code snippets retrieve the first ten outgoing payments on the given wallet
 ## List all outgoing payments on a wallet address
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -46,7 +46,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/outgoing-payment/outgoing-payment-list.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/quote-create.mdx
+++ b/docs/src/content/docs/sdk/quote-create.mdx
@@ -21,7 +21,7 @@ A quote is a commitment from an account servicing entity to deliver a particular
 This code snippet allows a client to create a quote with an `incomingAmount` when one is specified in the `INCOMING_PAYMENT_URL`.
 
 <Tabs syncKey="langs">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -46,7 +46,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/quote/quote-create.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 <PhpImport />
 <ChunkedSnippet
@@ -67,7 +67,7 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 This code snippet allows a client to create a quote with a `debitAmount`, which specifies the amount that will be deducted from the sender's wallet.
 
 <Tabs syncKey="langs">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -97,7 +97,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/quote/quote-create-debit-amount.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 <PhpImport />
 <ChunkedSnippet
@@ -122,7 +122,7 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 This code snippet allows a client to create a quote with a `receiveAmount`, which specifies the amount that the recipient's wallet will receive.
 
 <Tabs syncKey="langs">
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>

--- a/docs/src/content/docs/sdk/quote-get.mdx
+++ b/docs/src/content/docs/sdk/quote-get.mdx
@@ -23,7 +23,7 @@ These code snippets return the state and details of a specific quote, if found.
 ## Get the state of a quote
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -48,7 +48,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/quote/quote-get.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/token-revoke.mdx
+++ b/docs/src/content/docs/sdk/token-revoke.mdx
@@ -21,7 +21,7 @@ These code snippets enable the client to call a management endpoint to revoke th
 ## Revoke an access token
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -41,7 +41,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/token/token-revoke.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/token-rotate.mdx
+++ b/docs/src/content/docs/sdk/token-rotate.mdx
@@ -23,7 +23,7 @@ These code snippets enable the client to call a management endpoint to rotate th
 ## Rotate an access token
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <details>
@@ -48,7 +48,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/token/token-rotate.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/wallet-get-info.mdx
+++ b/docs/src/content/docs/sdk/wallet-get-info.mdx
@@ -21,7 +21,7 @@ These code snippets enable an authenticated client to verify a wallet address, g
 ## Retrieve public information for a wallet address
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton 
 href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 <details><summary>Initial configuration</summary><Ts /></details>
@@ -43,7 +43,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/wallet-address/wallet-address-get.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/content/docs/sdk/wallet-get-keys.mdx
+++ b/docs/src/content/docs/sdk/wallet-get-keys.mdx
@@ -23,7 +23,7 @@ These code snippets get the keys associated with the specified wallet address.
 ## Retrieve the public keys for a wallet address
 
 <Tabs>
-<TabItem label='TypeScript/JavaScript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 <LinkButton 
 href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 <details><summary>Initial configuration</summary><Ts /></details>
@@ -45,7 +45,7 @@ For TypeScript, run `tsx path/to/directory/index.ts`. <LinkOut href='https://git
 For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://github.com/interledger/open-payments-snippets/blob/main/wallet-address/wallet-address-get-keys.js'>View full JS source</LinkOut>
 
 </TabItem>
-<TabItem label="PHP">
+<TabItem label="PHP" icon='seti:php'>
 <LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
 
 <PhpImport />

--- a/docs/src/styles/openpayments.css
+++ b/docs/src/styles/openpayments.css
@@ -24,6 +24,15 @@ div.expressive-code figure.frame pre {
   border: 1px solid var(--sl-color-gray-5);
 }
 
+/* Tab styling adjustments */
+.sl-markdown-content.sl-markdown-content starlight-tabs [role='tabpanel'] {
+  margin-block-start: var(--space-s);
+}
+
+[role='tabpanel'] .sl-link-button {
+  margin-block-start: 0;
+}
+
 /* OpenAPI specification styling */
 div.panel {
   background-color: var(--sl-color-gray-7);


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

This PR adjusts some spacing in the tabs for SDK code snippets, and adds language icons to the tab labels

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
