### PR TITLE
ci: checkout submodules during doc deploy

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -21,6 +21,8 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v3
+        with:
+            submodules: true      
       - name: Install Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request
- Updating doc deploy action to checkout submodule
<!--
Provide a succinct description of what this pull request entails.
-->

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->
Related to OPE-235