### PR TITLE
docs: replace payment pointer with wallet address

### DIFF
--- a/openapi/wallet-address-server.yaml
+++ b/openapi/wallet-address-server.yaml
@@ -31,7 +31,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/wallet-address'
               examples:
-                Get wallet address for $ilp.interledger-test.dev/alice:
+                Get wallet address for https://ilp.interledger-test.dev/alice:
                   value:
                     id: 'https://ilp.interledger-test.dev/alice'
                     publicName: Alice


### PR DESCRIPTION
Open Payments uses wallet addresses, not payment pointers. I changed a payment pointer reference to a wallet address.