### PR TITLE
chore: disable codeblock formatting

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,4 @@ Dockerfile
 .gitignore
 .prettierignore
 landing
+open-payments-specifications/*

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "semi": false,
     "singleQuote": true,
     "jsxSingleQuote": true,
-    "trailingComma": "none"
+    "trailingComma": "none",
+    "embeddedLanguageFormatting": "off"
   }
 }


### PR DESCRIPTION
**Description of changes**

This disables prettier formatting of code blocks in markdown to allow us to preserve extra lines like this:

```ts
function something() {
    // need extra white space
    
    


    // like this
}
```

The other options would be to ignore the specific code blocks. Can switch to that if we miss the formatting.

Note that this technically isn't just limited to markdown codeblocks. It would also turn off formatting for, html tagged templates in .js files, for example. I dont think we'll run into that or similar scenario but if we did we could narrow the rule to `.md` files.

**Required**

- [ ] Used LinkOut component on external links
- [ ] Reviewed Vale errors and made changes where appropriate
- [ ] Ran Prettier
- [ ] Previewed updates in Netlify
- [ ] Received SME and/or peer approval if updates are significant
- [ ] Included a "fixes #" comment

**Conditional**

- [ ] Ensured sequence diagrams follow our style guide
- [ ] Included code samples where appropriate
- [ ] Updated related READMEs