### PR TITLE
docs: replace emojis for better dark mode visibility

### DIFF
--- a/docs/src/content/docs/resources/get-involved.mdx
+++ b/docs/src/content/docs/resources/get-involved.mdx
@@ -31,7 +31,7 @@ Before claiming an issue, ensure you have:
 - Understood the expected deliverables
 - Confirmed the issue hasn't been resolved in a recent pull request
 
-## 💻 Coding
+## 👨‍💻 Coding
 
 **Contribute to the codebase**: Help improve and expand the Open Payments ecosystem by contributing to:
 


### PR DESCRIPTION
**Description of changes**
On https://openpayments.dev/resources/get-involved/ the coding emoji 💻 was hard to see in dark mode, so I replaced it with 👨‍💻
**Required**

- [ ] Used LinkOut component on external links
- [ ] Reviewed Vale errors and made changes where appropriate
- [ ] Ran Prettier
- [ ] Previewed updates in Netlify
- [ ] Received SME and/or peer approval if updates are significant
- [ ] Included a "fixes #" comment

**Conditional**

- [ ] Ensured sequence diagrams follow our style guide
- [ ] Included code samples where appropriate
- [ ] Updated related READMEs