### PR TITLE
docs: escape dollar symbol - rendering as math instead of text

### DIFF
--- a/docs/src/content/docs/sdk/incoming-create.mdx
+++ b/docs/src/content/docs/sdk/incoming-create.mdx
@@ -12,7 +12,7 @@ import PhpImport from '/src/partials/php-import-initialize.mdx'
 
 Once an authorized client obtains the requisite grant from the recipient’s authentication server, the client must create an incoming payment resource before any payments can be sent to the recipient’s wallet address.
 
-These code snippets create an incoming payment of $10 USD at a given wallet address, allowing subsequent payments to be sent to that wallet address up to $10 USD.
+These code snippets create an incoming payment of \$10 USD at a given wallet address, allowing subsequent payments to be sent to that wallet address up to $10 USD.
 
 ## Before you begin
 


### PR DESCRIPTION
**Description of changes**
simple fix where $ sign is not escaped - causing  escape dollar symbol - rendering as math instead of text

**Required**

- [x] Ran Prettier
