### PR TITLE
chore: docs-design-system dependency bump

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@astrojs/starlight": "^0.34.7",
-    "@interledger/docs-design-system": "^0.9.0",
+    "@interledger/docs-design-system": "^0.10.0",
     "astro": "5.11.1",
     "katex": "^0.16.22",
     "mermaid": "^11.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^0.34.7
         version: 0.34.7(astro@5.11.1)
       '@interledger/docs-design-system':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.10.0
+        version: 0.10.0
       astro:
         specifier: 5.11.1
         version: 5.11.1(typescript@5.9.2)
@@ -1079,8 +1079,8 @@ packages:
     dev: false
     optional: true
 
-  /@interledger/docs-design-system@0.9.0:
-    resolution: {integrity: sha512-LpY+1OlqU4PNG+mQ82FgaD3gh8PrzY09oAwSeNAsxSg17qDkVQ1uqEVzU+jZLj3Yr2yiZ+lMSz1xq+efkGTxwQ==}
+  /@interledger/docs-design-system@0.10.0:
+    resolution: {integrity: sha512-KFlzLlrUHMDmRwaA7k6d+IEcVqbYjPFZjDTg39biUFtnHOP3FyAd8p2qzqFAi1qGyLM+Ji9ENFRRSlLNwPJhbg==}
     dependencies:
       mermaid: 11.8.1
     transitivePeerDependencies:


### PR DESCRIPTION
**Description of changes**
Updated the docs-design-system dependency to include a fix for text wrapping on long LinkOut components that were overflowing.

**Required**

- [ ] Used LinkOut component on external links
- [ ] Reviewed Vale errors and made changes where appropriate
- [ ] Ran Prettier
- [ ] Previewed updates in Netlify
- [ ] Received SME and/or peer approval if updates are significant
- [ ] Included a "fixes #" comment

**Conditional**

- [ ] Ensured sequence diagrams follow our style guide
- [ ] Included code samples where appropriate
- [ ] Updated related READMEs