### PR TITLE
docs: update hash verification code

### DIFF
--- a/docs/src/content/docs/es/identity/hash-verification.mdx
+++ b/docs/src/content/docs/es/identity/hash-verification.mdx
@@ -50,7 +50,7 @@ function verifyHash(
   authServerUrl,
   receivedHash
 ) {
-  const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${authServerUrl}/`
+  const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${authServerUrl}`
   const hash = createHash('sha-256').update(data).digest('base64')
 
   return hash === receivedHash

--- a/docs/src/content/docs/identity/hash-verification.mdx
+++ b/docs/src/content/docs/identity/hash-verification.mdx
@@ -50,7 +50,7 @@ function verifyHash(
   authServerUrl,
   receivedHash
 ) {
-  const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${authServerUrl}/`
+  const data = `${clientNonce}\n${interactNonce}\n${interactRef}\n${authServerUrl}`
   const hash = createHash('sha-256').update(data).digest('base64')
 
   return hash === receivedHash


### PR DESCRIPTION
**Description of changes**
The `data` variable used in the hash verification code snippet does not require trailing slash. The `authServerUrl` itself used in the grant request (and hash generation) may or may not contain a trailing slash, but the slash is not required.

**Required**

- [x] Used LinkOut component on external links
- [x] Reviewed Vale errors and made changes where appropriate
- [x] Ran Prettier
- [x] Previewed updates in Netlify
- [x] Received SME and/or peer approval if updates are significant
- [ ] Included a "fixes #" comment

**Conditional**

- [ ] Ensured sequence diagrams follow our style guide
- [ ] Included code samples where appropriate
- [ ] Updated related READMEs