### PR TITLE
docs: mi/748/es-ts-snippets-sync

### DIFF
--- a/docs/src/content/docs/es/guides/accept-otp-online-purchase.mdx
+++ b/docs/src/content/docs/es/guides/accept-otp-online-purchase.mdx
@@ -136,12 +136,12 @@ Esta llamada obtiene un token de acceso que permite a la aplicación cliente sol
         access: [
           {
             type: 'incoming-payment',
-            actions: ['create'],
-          },
-        ],
-      },
-    },
-  );
+            actions: ['create']
+          }
+        ]
+      }
+    }
+  )
   ```
   </TabItem>
   <TabItem label='Rust' icon='seti:rust'>
@@ -228,7 +228,7 @@ Recuerde que el monto total de la compra del cliente es de MXN 1400.
 <Tabs syncKey="lang">
   <TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
   ```ts wrap
-  const retailerIncomingPayment = await.client.incomingPayment.create(
+  const retailerIncomingPayment = await client.incomingPayment.create(
     {
       url: retailerWalletAddress.resourceServer,
       accessToken: retailerIncomingPaymentGrant.access_token.value
@@ -239,8 +239,8 @@ Recuerde que el monto total de la compra del cliente es de MXN 1400.
         value: '140000',
         assetCode: 'MXN',
         assetScale: 2
-      },
-    },
+      }
+    }
   )
   ```
   </TabItem>
@@ -546,7 +546,7 @@ Los pagos salientes requieren una concesión de autorización interactiva. Este 
               debitAmount: {
                 assetCode: 'MXN',
                 assetScale: 2,
-                value: '140000',
+                value: '140000'
               }
             }
           }
@@ -864,3 +864,7 @@ El siguiente es un ejemplo de respuesta proveniente del proveedor de billetera d
 }
 ```
 </details>
+
+:::note[Expiración del token de acceso]
+Si el token de acceso de una concesión ha expirado, llame a la <Badge text="POST" variant="success" /> [Rotate Access Token API](/apis/auth-server/operations/post-token/), luego utilice el nuevo token en la solicitud correspondiente.
+:::

--- a/docs/src/content/docs/es/guides/onetime-remittance-fixed-debit.mdx
+++ b/docs/src/content/docs/es/guides/onetime-remittance-fixed-debit.mdx
@@ -111,7 +111,7 @@ if err != nil {
  </TabItem>
 </Tabs>
 <details>
-<summary>Respuestas de ejemplo</summary>
+<summary>Ejemplo de respuesta</summary>
 El siguiente ejemplo muestra una respuesta del proveedor de billetera del remitente.
 ```json wrap
 {

--- a/docs/src/content/docs/es/guides/onetime-remittance-fixed-debit.mdx
+++ b/docs/src/content/docs/es/guides/onetime-remittance-fixed-debit.mdx
@@ -154,19 +154,19 @@ Esta llamada obtiene un token de acceso que permite a su aplicación solicitar l
         access: [
           {
             type: "incoming-payment",
-            actions: ["create"],
-          },
-        ],
-      },
-    },
-  );
+            actions: ["create"]
+          }
+        ]
+      }
+    }
+  )
 ````
  </TabItem>
  <TabItem label='Rust' icon='seti:rust'>
  ```rust wrap
  use open_payments::types::{AccessTokenRequest, AccessItem, IncomingPaymentAction, GrantRequest};
  let incoming_access = AccessTokenRequest {
-   access: vec![AccessItem::IncomingPayment { actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Complete], identifier: None }],
+   access: vec![AccessItem::IncomingPayment { actions: vec![IncomingPaymentAction::Create, IncomingPaymentAction::Complete], identifier: None }]
  };
  let incoming_grant_request = GrantRequest::new(incoming_access, None);
  let recipient_incoming_payment_grant = client
@@ -247,7 +247,7 @@ Esta llamada solicita la creación de un recurso de pago entrante en la cuenta d
     },
     {
       walletAddress: recipientWalletAddress.id
-    },
+    }
   )
 ```
  </TabItem>
@@ -549,7 +549,7 @@ Los pagos salientes requieren una concesión de autorización interactiva. Este 
               debitAmount: {
                 assetCode: 'USD',
                 assetScale: 2,
-                value: '10000', 
+                value: '10000'
               }
             }
           }
@@ -873,3 +873,7 @@ El siguiente ejemplo muestra una respuesta cuando se crea un recurso de pago sal
 ```
 
 </details>
+
+:::note[Expiración del token de acceso]
+Si el token de acceso de una concesión ha expirado, llame a la <Badge text="POST" variant="success" /> [Rotate Access Token API](/apis/auth-server/operations/post-token/), luego utilice el nuevo token en la solicitud correspondiente.
+:::

--- a/docs/src/content/docs/es/guides/onetime-remittance-fixed-receive.mdx
+++ b/docs/src/content/docs/es/guides/onetime-remittance-fixed-receive.mdx
@@ -113,7 +113,7 @@ Llame a la <Badge text="GET" variant="note" /> [Get Wallet Address API](/apis/wa
 </Tabs>
 
 <details>
-<summary>Respuestas de ejemplo</summary>
+<summary>Ejemplo de respuesta</summary>
 El siguiente ejemplo muestra una respuesta del proveedor de billetera del remitente.
 
 ```json wrap

--- a/docs/src/content/docs/es/guides/onetime-remittance-fixed-receive.mdx
+++ b/docs/src/content/docs/es/guides/onetime-remittance-fixed-receive.mdx
@@ -159,10 +159,10 @@ Esta llamada obtiene un token de acceso que permite a su aplicación solicitar l
           {
             type: 'incoming-payment',
             actions: ['create']
-          },
-        ],
-      },
-    },
+          }
+        ]
+      }
+    }
   );
   ```
   </TabItem>
@@ -251,8 +251,8 @@ Esta llamada solicita la creación de un recurso de pago entrante en la cuenta d
       accessToken: recipientIncomingPaymentGrant.access_token.value
     },
     {
-      walletAddress: recipientWalletAddress.id,
-    },
+      walletAddress: recipientWalletAddress.id
+    }
   )
   ```
   </TabItem>
@@ -464,14 +464,14 @@ method: QuoteMethod::Ilp,
 wallet_address: Some(sender_wallet_address.id.clone()),
 receiver: Some(recipient_incoming_payment.id.clone()),
 debit_amount: None,
-receive_amount: Some(Amount { value: "500000".into(), asset_code: "MXN".into(), asset_scale: 2 }),
+receive_amount: Some(Amount { value: "500000".into(), asset_code: "MXN".into(), asset_scale: 2 })
 };
 let sender_quote = client
 .quotes()
 .create(
 &sender_wallet_address.resource_server,
 &quote_request,
-Some(&sender_quote_grant.access_token.value),
+Some(&sender_quote_grant.access_token.value)
 )
 .await?;
 
@@ -492,9 +492,9 @@ Some(&sender_quote_grant.access_token.value),
   		ReceiveAmount: rs.Amount{
   			Value:      "500000",
   			AssetCode:  "MXN",
-  			AssetScale: 2,
-  		},
-  	},
+  			AssetScale: 2
+  		}
+  	}
   })
   if err != nil {
   	log.Fatalf("Error creating quote: %v\n", err)
@@ -862,7 +862,7 @@ if err != nil {
   </TabItem>
 </Tabs>
 
-Si la solicitud falla porque la cotización expiró, [solicite una nueva](#5-solicitar-la-creación-de-un-recurso-de-cotización) e intente otra vez. Si falla porque el token de acceso de la concesión de autorización ha expirado, llame a <Badge text="POST" variant="success" /> [Rotate Access Token API](/apis/auth-server/operations/post-token/) para obtener un nuevo token de acceso y, luego, vuelva a probar la solicitud con el nuevo token.
+Si la solicitud falla porque la cotización expiró, [solicite una nueva](#5-solicitar-la-creación-de-un-recurso-de-cotización) e intente otra vez.
 
 <details>
 <summary>Ejemplo de respuesta</summary>
@@ -891,4 +891,7 @@ El siguiente ejemplo muestra una respuesta del proveedor de billetera del remite
 }
 ```
 </details>
-````
+
+:::note[Expiración del token de acceso]
+Si el token de acceso de una concesión ha expirado, llame a la <Badge text="POST" variant="success" /> [Rotate Access Token API](/apis/auth-server/operations/post-token/), luego utilice el nuevo token en la solicitud correspondiente.
+:::

--- a/docs/src/content/docs/es/guides/outgoing-grant-future-payments.mdx
+++ b/docs/src/content/docs/es/guides/outgoing-grant-future-payments.mdx
@@ -89,7 +89,7 @@ El usuario indica que desea realizar pagos de hasta CAD 100 por mes durante tres
   ```ts
   const grant = await client.grant.request(
     {
-      url: userWalletAddress.authServer,
+      url: userWalletAddress.authServer
     },
     {
       access_token: {
@@ -99,26 +99,26 @@ El usuario indica que desea realizar pagos de hasta CAD 100 por mes durante tres
             type: 'outgoing-payment',
             actions: ['read', 'create'],
             limits: {
-              interval: 'R3/2025-05-20T13:00:00Z/P1M'
+              interval: 'R3/2025-05-20T13:00:00Z/P1M',
               debitAmount: {
                 assetCode: 'CAD',
                 assetScale: 2,
-                value: '10000',
-              },
-            },
-          },
-        ],
+                value: '10000'
+              }
+            }
+          }
+        ]
       },
       client: userWalletAddress.id,
       interact: {
         start: ['redirect'],
         finish: {
           method: 'redirect',
-          uri: 'https://cloudninebank.example.com/finish/T8jw5Xy',
-          nonce: NONCE,
-        },
-      },
-    },
+          uri: 'https://paymentplatform.example/finish/{...}', // where to redirect the user to after they've completed the interaction
+          nonce: NONCE
+        }
+      }
+    }
   );
   ```
 </TabItem>
@@ -235,14 +235,14 @@ Agregue la `interact_ref` devuelta en los parámetros de consulta del URI de red
 <Tabs syncKey='lang'>
   <TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
   ```ts wrap
-  const grant = await client.grant.continue(
+  const userOutgoingPaymentGrant = await client.grant.continue(
     {
-      accessToken: CONTINUE_ACCESS_TOKEN,
-      url: CONTINUE_URI,
+      accessToken: pendingUserOutgoingPaymentGrant.continue.access_token.value,
+      url: pendingUserOutgoingPaymentGrant.continue.uri
     },
     {
-      interact_ref: INTERACT_REF,
-    },
+      interact_ref: interactRef
+    }
   );
   ```
   </TabItem>
@@ -282,3 +282,7 @@ Agregue la `interact_ref` devuelta en los parámetros de consulta del URI de red
 </Tabs>
 
 Una respuesta exitosa proporciona a su aplicación un token de acceso. Ahora su aplicación puede emitir solicitudes de pago saliente hacia destinatarios futuros en función de la concesión. Cada solicitud debe hacer referencia al token de acceso.
+
+:::note[Expiración del token de acceso]
+Si una solicitud de pago saliente falla porque el token de acceso de la concesión ha expirado, puede llamar a la <Badge text="POST" variant="success" /> [Rotate Access Token API](/apis/auth-server/operations/post-token/), luego utilice el nuevo token en la solicitud de pago saliente.
+:::

--- a/docs/src/content/docs/es/guides/outgoing-grant-future-payments.mdx
+++ b/docs/src/content/docs/es/guides/outgoing-grant-future-payments.mdx
@@ -67,6 +67,19 @@ Supongamos que su usuario guardó su dirección de billetera en el perfil de su 
 </TabItem>
 </Tabs>
 
+<details>
+  <summary>Ejemplo de respuesta</summary>
+  ```json wrap
+  {
+    "id": "https://cloudninebank.example.com/user",
+    "assetCode": "CAD",
+    "assetScale": 2,
+    "authServer": "https://auth.cloudninebank.example.com/",
+    "resourceServer": "https://cloudninebank.example.com/op"
+  }
+  ```
+</details>
+
 ### 2. Solicitar una concesión de autorización interactiva para un pago saliente
 
 Utilice la información del servidor de autorización recibida en el paso anterior para llamar a la [Grant Request API](/es/apis/auth-server/operations/post-request). El propósito de esta llamada consiste en obtener un token que permita que el cliente solicite la creación de recursos de pago saliente en la cuenta de la billetera de su usuario.
@@ -199,6 +212,25 @@ if err != nil {
 </TabItem>
 </Tabs>
 
+<details>
+  <summary>Ejemplo de respuesta</summary>
+```json wrap
+{
+  "interact": {
+    "redirect": "https://auth.cloudninebank.example.com/{...}", // uri to redirect the user to, to begin interaction
+    "finish": "..." // unique key to secure the callback
+  },
+  "continue": {
+    "access_token": {
+      "value": "..." // access token for continuing the outgoing payment grant request
+    },
+    "uri": "https://auth.cloudninebank.example.com/continue/{...}", // uri for continuing the outgoing payment grant request
+    "wait": 30
+  }
+}
+```
+</details>
+
 #### Acerca del intervalo
 
 El intervalo que se emplea en esta guía es `R3/2025-05-20T13:00:00Z/P1M`. Recuerde que el usuario desea enviar pagos de hasta CAD 100 por mes durante tres meses. El intervalo se desglosa del siguiente modo:
@@ -282,6 +314,31 @@ Agregue la `interact_ref` devuelta en los parámetros de consulta del URI de red
 </Tabs>
 
 Una respuesta exitosa proporciona a su aplicación un token de acceso. Ahora su aplicación puede emitir solicitudes de pago saliente hacia destinatarios futuros en función de la concesión. Cada solicitud debe hacer referencia al token de acceso.
+
+<details>
+  <summary>Ejemplo de respuesta</summary>
+  ```json wrap
+  {
+    "access_token": {
+      "value": "...", // final access token required before creating outgoing payments
+      "manage": "https://auth.cloudninebank.example.com/token/{...}", // management uri for access token
+      "access": [
+        {
+          "type": "outgoing-payment",
+          "actions": ["create", "read"],
+          "identifier": "https://cloudninebank.example.com/user"
+        }
+      ]
+    },
+    "continue": {
+      "access_token": {
+        "value": "..." // access token for continuing the request
+      },
+      "uri": "https://auth.cloudninebank.example.com/continue/{...}" // continuation request uri
+    }
+  }
+  ```
+</details>
 
 :::note[Expiración del token de acceso]
 Si una solicitud de pago saliente falla porque el token de acceso de la concesión ha expirado, puede llamar a la <Badge text="POST" variant="success" /> [Rotate Access Token API](/apis/auth-server/operations/post-token/), luego utilice el nuevo token en la solicitud de pago saliente.

--- a/docs/src/content/docs/es/guides/recurring-remittance-fixed-debit.mdx
+++ b/docs/src/content/docs/es/guides/recurring-remittance-fixed-debit.mdx
@@ -426,7 +426,7 @@ En total, esta concesión de autorización permitirá al remitente realizar pago
 
 En nuestro ejemplo, suponemos que el IdP con el que interactuó su usuario (el remitente) cuenta con una interfaz de usuario. Cuando la interacción finaliza, el usuario regresa a su aplicación. Ahora su aplicación puede realizar una solicitud de continuación de la concesión de autorización de pago saliente.
 
-:::Nota
+:::note
 En una situación hipotética donde una interfaz de usuario no se encuentra disponible, analice la posibilidad de implementar un mecanismo de sondeo para verificar que se haya completado la interacción.
 :::
 

--- a/docs/src/content/docs/es/guides/recurring-remittance-fixed-debit.mdx
+++ b/docs/src/content/docs/es/guides/recurring-remittance-fixed-debit.mdx
@@ -105,7 +105,7 @@ if err != nil {
 </Tabs>
 
 <details>
-<summary>Respuestas de ejemplo</summary>
+<summary>Ejemplo de respuesta</summary>
 El siguiente ejemplo muestra una respuesta del proveedor de billetera del remitente. 
 ```json wrap
 {

--- a/docs/src/content/docs/es/guides/recurring-remittance-fixed-debit.mdx
+++ b/docs/src/content/docs/es/guides/recurring-remittance-fixed-debit.mdx
@@ -148,11 +148,11 @@ Esta llamada obtiene un token de acceso que permite a su aplicación solicitar l
         access: [
           {
             type: 'incoming-payment',
-            actions: ['create'],
-          },
-        ],
-      },
-    },
+            actions: ['create']
+          }
+        ]
+      }
+    }
   );
   ```
   </TabItem>
@@ -225,8 +225,8 @@ Esta llamada solicita la creación de un recurso de pago entrante en la cuenta d
       accessToken: recipientIncomingPaymentGrant.access_token.value
     },
     {
-      walletAddress: recipientWalletAddress.id,
-    },
+      walletAddress: recipientWalletAddress.id
+    }
   )
   ```
   </TabItem>
@@ -518,7 +518,7 @@ Utilice el token de acceso devuelto en la continuación de la concesión de auto
         assetCode: 'USD',
         assetScale: 2,
         value: '20000'
-      },
+      }
     }
   )
   ```

--- a/docs/src/content/docs/es/guides/recurring-remittance-fixed-receive.mdx
+++ b/docs/src/content/docs/es/guides/recurring-remittance-fixed-receive.mdx
@@ -169,7 +169,7 @@ Los pagos salientes requieren una concesión de autorización interactiva, que e
               receiveAmount: {
                 assetCode: 'MXN',
                 assetScale: 2,
-                value: '400000', 
+                value: '400000'
               }
             }
           }
@@ -384,11 +384,11 @@ Esta llamada obtiene un token de acceso que permite a su aplicación solicitar l
         access: [
           {
             type: 'incoming-payment',
-            actions: ['create'],
-          },
-        ],
-      },
-    },
+            actions: ['create']
+          }
+        ]
+      }
+    }
   );
   ```
   </TabItem>
@@ -461,8 +461,8 @@ Esta llamada solicita la creación de un recurso de pago entrante en la cuenta d
       accessToken: recipientIncomingPaymentGrant.access_token.value
     },
     {
-      walletAddress: recipientWalletAddress.id,
-    },
+      walletAddress: recipientWalletAddress.id
+    }
   )
   ```
   </TabItem>
@@ -694,7 +694,7 @@ Utilice el token de acceso devuelto en la continuación de la concesión de auto
     },
     {
       walletAddress: senderWalletAddress.id,
-      quoteId: senderQuote.id,
+      quoteId: senderQuote.id
     }
   )
   ```

--- a/docs/src/content/docs/es/guides/recurring-remittance-fixed-receive.mdx
+++ b/docs/src/content/docs/es/guides/recurring-remittance-fixed-receive.mdx
@@ -109,7 +109,7 @@ if err != nil {
 </Tabs>
 
 <details>
-<summary>Respuestas de ejemplo</summary>
+<summary>Ejemplo de respuesta</summary>
 El siguiente ejemplo muestra una respuesta del proveedor de billetera del remitente. 
 ```json wrap
 {

--- a/docs/src/content/docs/es/guides/recurring-subscription-incoming-amount.mdx
+++ b/docs/src/content/docs/es/guides/recurring-subscription-incoming-amount.mdx
@@ -107,7 +107,7 @@ if err != nil {
 </Tabs>
 
 <details>
-<summary>Respuestas de ejemplo</summary>
+<summary>Ejemplo de respuesta</summary>
 El siguiente ejemplo muestra una respuesta del proveedor de billetera del cliente.
 ```json wrap
 {

--- a/docs/src/content/docs/es/guides/recurring-subscription-incoming-amount.mdx
+++ b/docs/src/content/docs/es/guides/recurring-subscription-incoming-amount.mdx
@@ -148,11 +148,11 @@ Esta llamada obtiene un token de acceso que le permite solicitar la creación de
         access: [
           {
             type: "incoming-payment",
-            actions: ["create"],
-          },
-        ],
-      },
-    },
+            actions: ["create"]
+          }
+        ]
+      }
+    }
   );
 ```
 </TabItem>
@@ -232,8 +232,8 @@ Esta llamada solicita la creación de un recurso de pago entrante en la cuenta d
         value: '1500',  // The amount the service provider expects to receive in the first payment
         assetCode: 'USD',
         assetScale: 2
-      },
-    },
+      }
+    }
   )
 ```
 </TabItem>
@@ -394,7 +394,7 @@ La solicitud debe contener el `receiver`, que es la `id` del pago entrante del p
     {
       method: 'ilp',
       walletAddress: customerWalletAddress.id,
-      receiver: serviceProviderIncomingPayment.id,
+      receiver: serviceProviderIncomingPayment.id
     }
   )
 ```
@@ -485,7 +485,7 @@ Para los pagos recurrentes, incluya la propiedad `interval` para especificar la 
               debitAmount: {
                 assetCode: 'USD',
                 assetScale: 2,
-                value: '1500',
+                value: '1500'
               },
               interval: 'R12/2025-10-14T00:03:00Z/P1M'
             }

--- a/docs/src/content/docs/es/guides/split-payments.mdx
+++ b/docs/src/content/docs/es/guides/split-payments.mdx
@@ -65,17 +65,14 @@ Llame a la <Badge text="GET" variant="note" /> [Get Wallet Address](/es/apis/wal
   const customerWalletAddress = await client.walletAddress.get({
     url: 'https://cloudninebank.example.com/customer'
   })
-
-const merchantWalletAddress = await client.walletAddress.get({
-url: 'https://happylifebank.example.com/merchant'
-})
-
-const platformWalletAddress = await client.walletAddress.get({
-url: 'https://coolwallet.example.com/platform'
-})
-
-````
-</TabItem>
+  const merchantWalletAddress = await client.walletAddress.get({
+    url: 'https://happylifebank.example.com/merchant'
+  })
+  const platformWalletAddress = await client.walletAddress.get({
+    url: 'https://coolwallet.example.com/platform'
+  })
+```
+ </TabItem>
  <TabItem label='Rust' icon='seti:rust'>
  ```rust wrap
  let customer_wallet_address = client.wallet_address().get("https://cloudninebank.example.com/customer").await?;
@@ -85,28 +82,44 @@ url: 'https://coolwallet.example.com/platform'
  </TabItem>
   <TabItem label='Go' icon='seti:go'>
 
-  ```go wrap
-  customerWalletAddress, err := client.WalletAddress.Get(context.TODO(), op.WalletAddressGetParams{
-    URL: "https://cloudninebank.example.com/customer",
-  })
-  if err != nil {
-    log.Fatalf("Error fetching customer wallet address: %v\n", err)
-  }
-  merchantWalletAddress, err := client.WalletAddress.Get(context.TODO(), op.WalletAddressGetParams{
-    URL: "https://happylifebank.example.com/merchant",
-  })
-  if err != nil {
-    log.Fatalf("Error fetching merchant wallet address: %v\n", err)
-  }
-  platformWalletAddress, err := client.WalletAddress.Get(context.TODO(), op.WalletAddressGetParams{
-    URL: "https://coolwallet.example.com/platform",
-  })
-  if err != nil {
-    log.Fatalf("Error fetching platform wallet address: %v\n", err)
-  }
-  ```
+```go wrap
+customerWalletAddress, err := client.WalletAddress.Get(context.TODO(), op.WalletAddressGetParams{
+  URL: "https://cloudninebank.example.com/customer",
+})
+if err != nil {
+  log.Fatalf("Error fetching customer wallet address: %v\n", err)
+}
+merchantWalletAddress, err := client.WalletAddress.Get(context.TODO(), op.WalletAddressGetParams{
+  URL: "https://happylifebank.example.com/merchant",
+})
+if err != nil {
+  log.Fatalf("Error fetching merchant wallet address: %v\n", err)
+}
+platformWalletAddress, err := client.WalletAddress.Get(context.TODO(), op.WalletAddressGetParams{
+  URL: "https://coolwallet.example.com/platform",
+})
+if err != nil {
+  log.Fatalf("Error fetching platform wallet address: %v\n", err)
+}
+```
+
   </TabItem>
 </Tabs>
+
+<details>
+<summary>Ejemplo de respuesta</summary>
+El siguiente ejemplo muestra una respuesta del proveedor de billetera del consumidor. Los proveedores de billetera del comerciante y de la plataforma devolverán respuestas similares.
+```json wrap
+{
+  "id": "https://cloudninebank.example.com/customer",
+  "assetCode": "USD",
+  "assetScale": 2,
+  "authServer": "https://auth.cloudninebank.example.com/",
+  "resourceServer": "https://cloudninebank.example.com/op"
+}
+```
+
+</details>
 
 ### 2. Solicitar concesiones de autorización de pagos entrantes
 
@@ -212,6 +225,33 @@ if err != nil {
   </TabItem>
 </Tabs>
 
+<details>
+<summary>Ejemplo de respuesta</summary>
+El siguiente ejemplo muestra una respuesta del proveedor de billetera del comerciante. Se devolverá una respuesta similar de su proveedor de billetera.
+
+```json wrap
+{
+  "access_token": {
+    "value": "...", // access token value for incoming payment grant
+    "manage": "https://happylifebank.example.com/token/{...}", // management uri for access token
+    "access": [
+      {
+        "type": "incoming-payment",
+        "actions": ["create"]
+      }
+    ]
+  },
+  "continue": {
+    "access_token": {
+      "value": "..." // access token for continuing the request
+    },
+    "uri": "https://happylifebank.example.com/continue/{...}" // continuation request uri
+  }
+}
+```
+
+</details>
+
 ### 3. Solicitar la creación de recursos de pagos entrantes
 
 Use los tókenes de acceso devueltos en las respuestas anteriores para llamar a la <Badge text="POST" variant="success" /> [Create an Incoming Payment API](/es/apis/resource-server/operations/create-incoming-payment).
@@ -292,42 +332,75 @@ El `value` total de $100 es `10000`. El comerciante recibirá el 99 % (`9900`) y
 
   <TabItem label='Go' icon='seti:go'>
 
-  ```go wrap
-  // Merchant
-  merchantIncomingPayment, err := client.IncomingPayment.Create(context.TODO(), op.IncomingPaymentCreateParams{
-    BaseURL:     *merchantWalletAddress.ResourceServer,
-    AccessToken: merchantIncomingPaymentGrant.AccessToken.Value,
-    Payload: rs.CreateIncomingPaymentJSONBody{
-      WalletAddressSchema: *merchantWalletAddress.Id,
-      IncomingAmount: &rs.Amount{
-        Value:      "9900",
-        AssetCode:  "USD",
-        AssetScale: 2,
-      },
+```go wrap
+// Merchant
+merchantIncomingPayment, err := client.IncomingPayment.Create(context.TODO(), op.IncomingPaymentCreateParams{
+  BaseURL:     *merchantWalletAddress.ResourceServer,
+  AccessToken: merchantIncomingPaymentGrant.AccessToken.Value,
+  Payload: rs.CreateIncomingPaymentJSONBody{
+    WalletAddressSchema: *merchantWalletAddress.Id,
+    IncomingAmount: &rs.Amount{
+      Value:      "9900",
+      AssetCode:  "USD",
+      AssetScale: 2,
     },
-  })
-  if err != nil {
-    log.Fatalf("Error creating merchant incoming payment: %v\n", err)
-  }
-  // Platform
-  platformIncomingPayment, err := client.IncomingPayment.Create(context.TODO(), op.IncomingPaymentCreateParams{
-    BaseURL:     *platformWalletAddress.ResourceServer,
-    AccessToken: platformIncomingPaymentGrant.AccessToken.Value,
-    Payload: rs.CreateIncomingPaymentJSONBody{
-      WalletAddressSchema: *platformWalletAddress.Id,
-      IncomingAmount: &rs.Amount{
-        Value:      "100",
-        AssetCode:  "USD",
-        AssetScale: 2,
-      },
+  },
+})
+if err != nil {
+  log.Fatalf("Error creating merchant incoming payment: %v\n", err)
+}
+// Platform
+platformIncomingPayment, err := client.IncomingPayment.Create(context.TODO(), op.IncomingPaymentCreateParams{
+  BaseURL:     *platformWalletAddress.ResourceServer,
+  AccessToken: platformIncomingPaymentGrant.AccessToken.Value,
+  Payload: rs.CreateIncomingPaymentJSONBody{
+    WalletAddressSchema: *platformWalletAddress.Id,
+    IncomingAmount: &rs.Amount{
+      Value:      "100",
+      AssetCode:  "USD",
+      AssetScale: 2,
     },
-  })
-  if err != nil {
-    log.Fatalf("Error creating platform incoming payment: %v\n", err)
-  }
-  ```
+  },
+})
+if err != nil {
+  log.Fatalf("Error creating platform incoming payment: %v\n", err)
+}
+```
+
   </TabItem>
 </Tabs>
+
+<details>
+<summary>Ejemplo de respuesta</summary>
+El siguiente ejemplo muestra una respuesta del proveedor de billetera del comerciante. Se devolverá una respuesta similar de su proveedor de billetera, pero el valor `value` de su monto entrante será `100`.
+
+```json wrap
+{
+  "id": "https://happylifebank.example.com/incoming-payments/{...}",
+  "walletAddress": "https://happylifebank.example.com/merchant",
+  "incomingAmount": {
+    "value": "9900",
+    "assetCode": "USD",
+    "assetScale": 2
+  },
+  "receivedAmount": {
+    "value": "0",
+    "assetCode": "USD",
+    "assetScale": 2
+  },
+  "completed": false,
+  "createdAt": "2025-03-12T23:20:50.52Z",
+  "methods": [
+    {
+      "type": "ilp",
+      "ilpAddress": "...",
+      "sharedSecret": "..."
+    }
+  ]
+}
+```
+
+</details>
 
 ### 4. Solicitar una concesión de autorización para una cotización
 
@@ -371,30 +444,57 @@ El propósito de esta llamada consiste en obtener un token de acceso que permita
 
   <TabItem label='Go' icon='seti:go'>
 
-  ```go wrap
-  quoteAccess := as.AccessQuote{
-    Type:    as.Quote,
-    Actions: []as.AccessQuoteActions{as.Create},
-  }
-  quoteAccessItem := as.AccessItem{}
-  if err := quoteAccessItem.FromAccessQuote(quoteAccess); err != nil {
-    log.Fatalf("Error creating AccessItem: %v\n", err)
-  }
-  quoteAccessToken := struct {
-    Access as.Access `json:"access"`
-  }{
-    Access: []as.AccessItem{quoteAccessItem},
-  }
-  customerQuoteGrant, err := client.Grant.Request(context.TODO(), op.GrantRequestParams{
-    URL:         *customerWalletAddress.AuthServer,
-    RequestBody: as.GrantRequestWithAccessToken{AccessToken: quoteAccessToken},
-  })
-  if err != nil {
-    log.Fatalf("Error requesting quote grant: %v\n", err)
-  }
-  ```
+```go wrap
+quoteAccess := as.AccessQuote{
+  Type:    as.Quote,
+  Actions: []as.AccessQuoteActions{as.Create},
+}
+quoteAccessItem := as.AccessItem{}
+if err := quoteAccessItem.FromAccessQuote(quoteAccess); err != nil {
+  log.Fatalf("Error creating AccessItem: %v\n", err)
+}
+quoteAccessToken := struct {
+  Access as.Access `json:"access"`
+}{
+  Access: []as.AccessItem{quoteAccessItem},
+}
+customerQuoteGrant, err := client.Grant.Request(context.TODO(), op.GrantRequestParams{
+  URL:         *customerWalletAddress.AuthServer,
+  RequestBody: as.GrantRequestWithAccessToken{AccessToken: quoteAccessToken},
+})
+if err != nil {
+  log.Fatalf("Error requesting quote grant: %v\n", err)
+}
+```
+
   </TabItem>
 </Tabs>
+
+<details>
+  <summary>Ejemplo de respuesta</summary>
+
+```json wrap
+{
+  "access_token": {
+    "value": "...", // access token value for quote grant
+    "manage": "https:/cloudninebank.example.com/token/{...}", // management uri for access token
+    "access": [
+      {
+        "type": "quote",
+        "actions": ["create"]
+      }
+    ]
+  },
+  "continue": {
+    "access_token": {
+      "value": "..." // access token for continuing the request
+    },
+    "uri": "https://auth.cloudninebank.example.com/continue/{...}" // continuation request uri
+  }
+}
+```
+
+</details>
 
 ### 5. Solicitar la creación de recursos de cotización
 
@@ -464,34 +564,35 @@ Posteriormente, llame de nuevo a la Create Quote API y solicite un recurso de co
  </TabItem>
  <TabItem label='Go' icon='seti:go'>
 
-  ```go wrap
-  // Merchant
-  merchantQuote, err := client.Quote.Create(context.TODO(), op.QuoteCreateParams{
-    BaseURL:     *customerWalletAddress.ResourceServer,
-    AccessToken: customerQuoteGrant.AccessToken.Value,
-    Payload: rs.CreateQuoteJSONBody0{
-      WalletAddressSchema: *customerWalletAddress.Id,
-      Receiver:            *merchantIncomingPayment.Id,
-      Method:              "ilp",
-    },
-  })
-  if err != nil {
-    log.Fatalf("Error creating merchant quote: %v\n", err)
-  }
-  // Platform
-  platformQuote, err := client.Quote.Create(context.TODO(), op.QuoteCreateParams{
-    BaseURL:     *customerWalletAddress.ResourceServer,
-    AccessToken: customerQuoteGrant.AccessToken.Value,
-    Payload: rs.CreateQuoteJSONBody0{
-      WalletAddressSchema: *customerWalletAddress.Id,
-      Receiver:            *platformIncomingPayment.Id,
-      Method:              "ilp",
-    },
-  })
-  if err != nil {
-    log.Fatalf("Error creating platform quote: %v\n", err)
-  }
-  ```
+```go wrap
+// Merchant
+merchantQuote, err := client.Quote.Create(context.TODO(), op.QuoteCreateParams{
+  BaseURL:     *customerWalletAddress.ResourceServer,
+  AccessToken: customerQuoteGrant.AccessToken.Value,
+  Payload: rs.CreateQuoteJSONBody0{
+    WalletAddressSchema: *customerWalletAddress.Id,
+    Receiver:            *merchantIncomingPayment.Id,
+    Method:              "ilp",
+  },
+})
+if err != nil {
+  log.Fatalf("Error creating merchant quote: %v\n", err)
+}
+// Platform
+platformQuote, err := client.Quote.Create(context.TODO(), op.QuoteCreateParams{
+  BaseURL:     *customerWalletAddress.ResourceServer,
+  AccessToken: customerQuoteGrant.AccessToken.Value,
+  Payload: rs.CreateQuoteJSONBody0{
+    WalletAddressSchema: *customerWalletAddress.Id,
+    Receiver:            *platformIncomingPayment.Id,
+    Method:              "ilp",
+  },
+})
+if err != nil {
+  log.Fatalf("Error creating platform quote: %v\n", err)
+}
+```
+
 </TabItem>
 </Tabs>
 
@@ -499,6 +600,32 @@ Cada respuesta devuelve un `receiveAmount`, un `debitAmount` y demás informaci�
 
 - `receiveAmount`: el valor del `incomingAmount` del recurso de pago entrante.
 - `debitAmount`: el monto que el consumidor debe pagar al recurso de pago entrante (el `receiveAmount` más cualquier tarifa que corresponda).
+
+<details>
+<summary>Ejemplo de respuesta</summary>
+  El siguiente ejemplo muestra una respuesta del proveedor de billetera del comerciante. Se devolverá una respuesta similar de su proveedor de billetera.
+
+```json wrap
+{
+  "id": "https://cloudninebank.example.com/quotes/{...}", // url identifying the quote
+  "walletAddress": "https://cloudninebank.example.com/customer",
+  "receiver": "https://happylifebank.example.com/incoming-payments/{...}", // url of the incoming payment the quote is created for
+  "debitAmount": {
+    "value": "9900",
+    "assetCode": "USD",
+    "assetScale": 2
+  },
+  "receiveAmount": {
+    "value": "9900",
+    "assetCode": "USD",
+    "assetScale": 2
+  },
+  "method": "ilp",
+  "createdAt": "2025-03-12T23:22:51.50Z"
+}
+```
+
+</details>
 
 ### 6. Solicitar una concesión de autorización interactiva para un pago saliente
 
@@ -524,138 +651,162 @@ Incluya lo siguiente en la solicitud, además de los parámetros requeridos:
   ```ts wrap
   combinedQuoteAmount = '10000' // 9900 + 100
 
-  const pendingCustomerOutgoingPaymentGrant = await client.grant.request(
-    {
-      url: customerWalletAddress.authServer
-    },
-    {
-      access_token: {
-        access: [
-          {
-            identifier: customerWalletAddress.id,
-            type: 'outgoing-payment',
-            actions: ['create'],
-            limits: {
-              debitAmount: {
-                assetCode: 'USD',
-                assetScale: 2,
-                value: combinedQuoteAmount
-              }
-            }
-          }
-        ]
-      },
-      interact: {
-        start: ['redirect'],
-        finish: {
-          method: 'redirect',
-          uri: 'https://paymentplatform.example/finish/{...}', // where to redirect the customer after they've completed interaction
-          nonce: NONCE
-        }
-      }
-    }
-  )
-  ```
- </TabItem>
-<TabItem label='Rust' icon='seti:rust'>
- ```rust wrap
- use open_payments::types::{AccessTokenRequest, AccessItem, OutgoingPaymentAction, InteractRequest, InteractStart, InteractFinish, InteractFinishMethod, AccessLimits, Amount, GrantRequest};
+const pendingCustomerOutgoingPaymentGrant = await client.grant.request(
+{
+url: customerWalletAddress.authServer
+},
+{
+access_token: {
+access: [
+{
+identifier: customerWalletAddress.id,
+type: 'outgoing-payment',
+actions: ['create'],
+limits: {
+debitAmount: {
+assetCode: 'USD',
+assetScale: 2,
+value: combinedQuoteAmount
+}
+}
+}
+]
+},
+interact: {
+start: ['redirect'],
+finish: {
+method: 'redirect',
+uri: 'https://paymentplatform.example/finish/{...}', // where to redirect the customer after they've completed interaction
+nonce: NONCE
+}
+}
+}
+)
 
- let merchant_amount = match merchant_quote.debit_amount.as_ref() {
-   Some(a) => &a.value,
-   None => {
-     eprintln!("Missing debit_amount on merchant quote");
-     return Ok(());
-   }
- };
- let platform_amount = match platform_quote.debit_amount.as_ref() {
-   Some(a) => &a.value,
-   None => {
-     eprintln!("Missing debit_amount on platform quote");
-     return Ok(());
-   }
- };
- let merchant_value = match merchant_amount.parse::<i64>() {
-   Ok(v) => v,
-   Err(_) => {
-     eprintln!("Invalid merchant debit_amount value");
-     return Ok(());
-   }
- };
- let platform_value = match platform_amount.parse::<i64>() {
-   Ok(v) => v,
-   Err(_) => {
-     eprintln!("Invalid platform debit_amount value");
-     return Ok(());
-   }
- };
- let combined_quote_amount = merchant_value + platform_value;
- let outgoing_access = AccessTokenRequest {
-   access: vec![AccessItem::OutgoingPayment {
-     identifier: Some(customer_wallet_address.id.clone()),
-     actions: vec![OutgoingPaymentAction::Create],
-     limits: Some(AccessLimits { debit_amount: Some(Amount { value: combined_quote_amount.to_string(), asset_code: "USD".into(), asset_scale: 2 }), ..Default::default() }),
-   }],
- };
- let interact = InteractRequest { start: Some(vec![InteractStart::Redirect]), finish: Some(InteractFinish { method: InteractFinishMethod::Redirect, uri: Some("https://paymentplatform.example/finish/{...}".into()), nonce: Some("NONCE".into()) }) };
- let outgoing_grant_request = GrantRequest::new(outgoing_access, Some(interact));
- let pending_customer_outgoing_payment_grant = client
-   .grant()
-   .request(&customer_wallet_address.auth_server, &outgoing_grant_request)
-   .await?;
- ```
+````
+</TabItem>
+<TabItem label='Rust' icon='seti:rust'>
+```rust wrap
+use open_payments::types::{AccessTokenRequest, AccessItem, OutgoingPaymentAction, InteractRequest, InteractStart, InteractFinish, InteractFinishMethod, AccessLimits, Amount, GrantRequest};
+
+let merchant_amount = match merchant_quote.debit_amount.as_ref() {
+ Some(a) => &a.value,
+ None => {
+   eprintln!("Missing debit_amount on merchant quote");
+   return Ok(());
+ }
+};
+let platform_amount = match platform_quote.debit_amount.as_ref() {
+ Some(a) => &a.value,
+ None => {
+   eprintln!("Missing debit_amount on platform quote");
+   return Ok(());
+ }
+};
+let merchant_value = match merchant_amount.parse::<i64>() {
+ Ok(v) => v,
+ Err(_) => {
+   eprintln!("Invalid merchant debit_amount value");
+   return Ok(());
+ }
+};
+let platform_value = match platform_amount.parse::<i64>() {
+ Ok(v) => v,
+ Err(_) => {
+   eprintln!("Invalid platform debit_amount value");
+   return Ok(());
+ }
+};
+let combined_quote_amount = merchant_value + platform_value;
+let outgoing_access = AccessTokenRequest {
+ access: vec![AccessItem::OutgoingPayment {
+   identifier: Some(customer_wallet_address.id.clone()),
+   actions: vec![OutgoingPaymentAction::Create],
+   limits: Some(AccessLimits { debit_amount: Some(Amount { value: combined_quote_amount.to_string(), asset_code: "USD".into(), asset_scale: 2 }), ..Default::default() }),
+ }],
+};
+let interact = InteractRequest { start: Some(vec![InteractStart::Redirect]), finish: Some(InteractFinish { method: InteractFinishMethod::Redirect, uri: Some("https://paymentplatform.example/finish/{...}".into()), nonce: Some("NONCE".into()) }) };
+let outgoing_grant_request = GrantRequest::new(outgoing_access, Some(interact));
+let pending_customer_outgoing_payment_grant = client
+ .grant()
+ .request(&customer_wallet_address.auth_server, &outgoing_grant_request)
+ .await?;
+````
+
  </TabItem>
 
   <TabItem label='Go' icon='seti:go'>
 
-  ```go wrap
-  combinedQuoteAmount := "10000" // merchantQuote.DebitAmount.Value + platformQuote.DebitAmount.Value
-  limits := as.LimitsOutgoing{}
-  if err := limits.FromLimitsOutgoing1(as.LimitsOutgoing1{
-    DebitAmount: as.Amount{
-      Value:      combinedQuoteAmount,
-      AssetCode:  "USD",
-      AssetScale: 2,
-    },
-  }); err != nil {
-    log.Fatalf("Error creating limits: %v\n", err)
-  }
-  outgoingAccess := as.AccessOutgoing{
-    Type:       as.OutgoingPayment,
-    Actions:    []as.AccessOutgoingActions{as.AccessOutgoingActionsCreate},
-    Identifier: *customerWalletAddress.Id,
-    Limits:     &limits,
-  }
-  outgoingAccessItem := as.AccessItem{}
-  if err := outgoingAccessItem.FromAccessOutgoing(outgoingAccess); err != nil {
-    log.Fatalf("Error creating AccessItem: %v\n", err)
-  }
-  outgoingAccessToken := struct {
-    Access as.Access `json:"access"`
-  }{
-    Access: []as.AccessItem{outgoingAccessItem},
-  }
-  interact := &as.InteractRequest{
-    Start: []as.InteractRequestStart{as.InteractRequestStartRedirect},
-    Finish: &as.InteractRequestFinish{
-      Method: as.Redirect,
-      Uri:    "https://paymentplatform.example/finish/{...}", // where to redirect the customer after they've completed interaction
-      Nonce:  NONCE,
-    },
-  }
-  pendingCustomerOutgoingPaymentGrant, err := client.Grant.Request(context.TODO(), op.GrantRequestParams{
-    URL: *customerWalletAddress.AuthServer,
-    RequestBody: as.GrantRequestWithAccessToken{
-      AccessToken: outgoingAccessToken,
-      Interact:    interact,
-    },
-  })
-  if err != nil {
-    log.Fatalf("Error requesting outgoing payment grant: %v\n", err)
-  }
-  ```
+```go wrap
+combinedQuoteAmount := "10000" // merchantQuote.DebitAmount.Value + platformQuote.DebitAmount.Value
+limits := as.LimitsOutgoing{}
+if err := limits.FromLimitsOutgoing1(as.LimitsOutgoing1{
+  DebitAmount: as.Amount{
+    Value:      combinedQuoteAmount,
+    AssetCode:  "USD",
+    AssetScale: 2,
+  },
+}); err != nil {
+  log.Fatalf("Error creating limits: %v\n", err)
+}
+outgoingAccess := as.AccessOutgoing{
+  Type:       as.OutgoingPayment,
+  Actions:    []as.AccessOutgoingActions{as.AccessOutgoingActionsCreate},
+  Identifier: *customerWalletAddress.Id,
+  Limits:     &limits,
+}
+outgoingAccessItem := as.AccessItem{}
+if err := outgoingAccessItem.FromAccessOutgoing(outgoingAccess); err != nil {
+  log.Fatalf("Error creating AccessItem: %v\n", err)
+}
+outgoingAccessToken := struct {
+  Access as.Access `json:"access"`
+}{
+  Access: []as.AccessItem{outgoingAccessItem},
+}
+interact := &as.InteractRequest{
+  Start: []as.InteractRequestStart{as.InteractRequestStartRedirect},
+  Finish: &as.InteractRequestFinish{
+    Method: as.Redirect,
+    Uri:    "https://paymentplatform.example/finish/{...}", // where to redirect the customer after they've completed interaction
+    Nonce:  NONCE,
+  },
+}
+pendingCustomerOutgoingPaymentGrant, err := client.Grant.Request(context.TODO(), op.GrantRequestParams{
+  URL: *customerWalletAddress.AuthServer,
+  RequestBody: as.GrantRequestWithAccessToken{
+    AccessToken: outgoingAccessToken,
+    Interact:    interact,
+  },
+})
+if err != nil {
+  log.Fatalf("Error requesting outgoing payment grant: %v\n", err)
+}
+```
+
   </TabItem>
 </Tabs>
+
+<details>
+  <summary>Ejemplo de respuesta</summary>
+
+```json wrap
+{
+  "interact": {
+    "redirect": "https://auth.cloudninebank.example.com/{...}", // uri to redirect the customer to, to begin interaction
+    "finish": "..." // unique key to secure the callback
+  },
+  "continue": {
+    "access_token": {
+      "value": "..." // access token for continuing the outgoing payment grant request
+    },
+    "uri": "https://auth.cloudninebank.example.com/continue/{...}", // uri for continuing the outgoing payment grant request
+    "wait": 30
+  }
+}
+```
+
+</details>
 
 ### 7. Comenzar la interacción con el consumidor
 
@@ -710,18 +861,49 @@ Incluya la `interact_ref` devuelta en los parámetros de consulta del URI de red
 
  <TabItem label='Go' icon='seti:go'>
 
-  ```go wrap
-  customerOutgoingPaymentGrant, err := client.Grant.Continue(context.TODO(), op.GrantContinueParams{
-    URL:         pendingCustomerOutgoingPaymentGrant.Continue.Uri,
-    AccessToken: pendingCustomerOutgoingPaymentGrant.Continue.AccessToken.Value,
-    InteractRef: INTERACT_REF
-  })
-  if err != nil {
-    log.Fatalf("Error continuing grant: %v\n", err)
-  }
-  ```
+```go wrap
+customerOutgoingPaymentGrant, err := client.Grant.Continue(context.TODO(), op.GrantContinueParams{
+  URL:         pendingCustomerOutgoingPaymentGrant.Continue.Uri,
+  AccessToken: pendingCustomerOutgoingPaymentGrant.Continue.AccessToken.Value,
+  InteractRef: INTERACT_REF
+})
+if err != nil {
+  log.Fatalf("Error continuing grant: %v\n", err)
+}
+```
+
   </TabItem>
 </Tabs>
+
+<details>
+  <summary>Ejemplo de respuesta</summary>
+
+```json wrap
+{
+  "access_token": {
+    "value": "...", // final access token required before creating outgoing payments
+    "manage": "https://auth.cloudninebank.example.com/token/{...}", // management uri for access token
+    "access": [
+      {
+        "type": "outgoing-payment",
+        "actions": ["create"],
+        "identifier": "https://cloudninebank.example.com/customer",
+        "limits": {
+          "receiver": "https://happylifebank.example.com/incoming-payments/{...}" // url of the incoming payment that's being paid
+        }
+      }
+    ]
+  },
+  "continue": {
+    "access_token": {
+      "value": "..." // access token for continuing the request
+    },
+    "uri": "https://auth.cloudninebank.example.com/continue/{...}" // continuation request uri
+  }
+}
+```
+
+</details>
 
 ### 10. Solicitar la creación de recursos de pagos salientes
 
@@ -790,40 +972,41 @@ El propósito de estas llamadas consiste en solicitar la creación de un recurso
 
   <TabItem label='Go' icon='seti:go'>
 
-  ```go wrap
-  // Merchant
-  var merchantOutgoingPayload rs.CreateOutgoingPaymentRequest
-  if err := merchantOutgoingPayload.FromCreateOutgoingPaymentWithQuote(rs.CreateOutgoingPaymentWithQuote{
-    WalletAddressSchema: *customerWalletAddress.Id,
-    QuoteId:             *merchantQuote.Id,
-  }); err != nil {
-    log.Fatalf("Error creating merchant payload: %v\n", err)
-  }
-  customerOutgoingPaymentToMerchant, err := client.OutgoingPayment.Create(context.TODO(), op.OutgoingPaymentCreateParams{
-    BaseURL:     *customerWalletAddress.ResourceServer,
-    AccessToken: customerOutgoingPaymentGrant.AccessToken.Value,
-    Payload:     merchantOutgoingPayload,
-  })
-  if err != nil {
-    log.Fatalf("Error creating outgoing payment to merchant: %v\n", err)
-  }
-  // Platform
-  var platformOutgoingPayload rs.CreateOutgoingPaymentRequest
-  if err := platformOutgoingPayload.FromCreateOutgoingPaymentWithQuote(rs.CreateOutgoingPaymentWithQuote{
-    WalletAddressSchema: *customerWalletAddress.Id,
-    QuoteId:             *platformQuote.Id,
-  }); err != nil {
-    log.Fatalf("Error creating platform payload: %v\n", err)
-  }
-  customerOutgoingPaymentToPlatform, err := client.OutgoingPayment.Create(context.TODO(), op.OutgoingPaymentCreateParams{
-    BaseURL:     *customerWalletAddress.ResourceServer,
-    AccessToken: customerOutgoingPaymentGrant.AccessToken.Value,
-    Payload:     platformOutgoingPayload,
-  })
-  if err != nil {
-    log.Fatalf("Error creating outgoing payment to platform: %v\n", err)
-  }
-  ```
+```go wrap
+// Merchant
+var merchantOutgoingPayload rs.CreateOutgoingPaymentRequest
+if err := merchantOutgoingPayload.FromCreateOutgoingPaymentWithQuote(rs.CreateOutgoingPaymentWithQuote{
+  WalletAddressSchema: *customerWalletAddress.Id,
+  QuoteId:             *merchantQuote.Id,
+}); err != nil {
+  log.Fatalf("Error creating merchant payload: %v\n", err)
+}
+customerOutgoingPaymentToMerchant, err := client.OutgoingPayment.Create(context.TODO(), op.OutgoingPaymentCreateParams{
+  BaseURL:     *customerWalletAddress.ResourceServer,
+  AccessToken: customerOutgoingPaymentGrant.AccessToken.Value,
+  Payload:     merchantOutgoingPayload,
+})
+if err != nil {
+  log.Fatalf("Error creating outgoing payment to merchant: %v\n", err)
+}
+// Platform
+var platformOutgoingPayload rs.CreateOutgoingPaymentRequest
+if err := platformOutgoingPayload.FromCreateOutgoingPaymentWithQuote(rs.CreateOutgoingPaymentWithQuote{
+  WalletAddressSchema: *customerWalletAddress.Id,
+  QuoteId:             *platformQuote.Id,
+}); err != nil {
+  log.Fatalf("Error creating platform payload: %v\n", err)
+}
+customerOutgoingPaymentToPlatform, err := client.OutgoingPayment.Create(context.TODO(), op.OutgoingPaymentCreateParams{
+  BaseURL:     *customerWalletAddress.ResourceServer,
+  AccessToken: customerOutgoingPaymentGrant.AccessToken.Value,
+  Payload:     platformOutgoingPayload,
+})
+if err != nil {
+  log.Fatalf("Error creating outgoing payment to platform: %v\n", err)
+}
+```
+
   </TabItem>
 </Tabs>
 
@@ -856,4 +1039,3 @@ El siguiente ejemplo muestra una respuesta cuando se crea un recurso de pago sal
 ```
 
 </details>
-````

--- a/docs/src/content/docs/es/guides/split-payments.mdx
+++ b/docs/src/content/docs/es/guides/split-payments.mdx
@@ -119,28 +119,25 @@ Si usted y el comerciante utilizan la misma entidad que administra cuentas, y la
 :::
 
 <Tabs syncKey="lang">
-<TabItem label='Merchant' icon='seti:javascript'>
-```ts wrap
-const merchantIncomingPaymentGrant = await client.grant.request(
-  {
-    url: merchantWalletAddress.authServer
-  },
-  {
-    access_token: {
-      access: [
-        {
-          type: "incoming-payment",
-          actions: ["read", "create"],
-        },
-      ],
-    },
-  },
-);
-````
-
-</TabItem>
-<TabItem label='Platform' icon='seti:javascript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
   ```ts wrap
+  // Merchant
+  const merchantIncomingPaymentGrant = await client.grant.request(
+    {
+      url: merchantWalletAddress.authServer
+    },
+    {
+      access_token: {
+        access: [
+          {
+            type: "incoming-payment",
+            actions: ["create"]
+          }
+        ]
+      }
+    }
+  );
+  // Platform
   const platformIncomingPaymentGrant = await client.grant.request(
     {
       url: platformWalletAddress.authServer
@@ -150,14 +147,14 @@ const merchantIncomingPaymentGrant = await client.grant.request(
         access: [
           {
             type: "incoming-payment",
-            actions: ["read", "create"],
-          },
-        ],
-      },
-    },
+            actions: ["create"]
+          }
+        ]
+      }
+    }
   );
   ```
-</TabItem>
+ </TabItem>
 
 <TabItem label='Rust' icon='seti:rust'>
  ```rust wrap
@@ -233,8 +230,9 @@ Incluya lo siguiente en ambas solicitudes, junto con cualquier otro parámetro r
 El `value` total de $100 es `10000`. El comerciante recibirá el 99 % (`9900`) y usted recibirá el 1 % (`100`).
 
 <Tabs syncKey="lang">
-<TabItem label='Merchant' icon='seti:javascript'>
+  <TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
   ```ts wrap
+  // Merchant
   const merchantIncomingPayment = await client.incomingPayment.create(
     {
       url: merchantWalletAddress.resourceServer,
@@ -246,13 +244,10 @@ El `value` total de $100 es `10000`. El comerciante recibirá el 99 % (`9900`) y
         value: '9900',
         assetCode: 'USD',
         assetScale: 2
-      },
-    },
+      }
+    }
   )
-  ```
-</TabItem>
-<TabItem label='Platform' icon='seti:javascript'>
-  ```ts wrap
+  // Platform
   const platformIncomingPayment = await client.incomingPayment.create(
     {
       url: platformWalletAddress.resourceServer,
@@ -264,10 +259,10 @@ El `value` total de $100 es `10000`. El comerciante recibirá el 99 % (`9900`) y
         value: '100',
         assetCode: 'USD',
         assetScale: 2
-      },
-    },
+      }
+    }
   )
-  ```
+```
 </TabItem>
 <TabItem label='Rust' icon='seti:rust'>
  ```rust wrap
@@ -296,7 +291,7 @@ El `value` total de $100 es `10000`. El comerciante recibirá el 99 % (`9900`) y
  </TabItem>
 
   <TabItem label='Go' icon='seti:go'>
-  
+
   ```go wrap
   // Merchant
   merchantIncomingPayment, err := client.IncomingPayment.Create(context.TODO(), op.IncomingPaymentCreateParams{
@@ -352,7 +347,7 @@ El propósito de esta llamada consiste en obtener un token de acceso que permita
         access: [
           {
             type: 'quote',
-            actions: ['create', 'read']
+            actions: ['create']
           }
         ]
       }
@@ -375,7 +370,7 @@ El propósito de esta llamada consiste en obtener un token de acceso que permita
   </TabItem>
 
   <TabItem label='Go' icon='seti:go'>
-  
+
   ```go wrap
   quoteAccess := as.AccessQuote{
     Type:    as.Quote,
@@ -412,8 +407,9 @@ Primero, solicitemos un recurso de cotización asociado con el comerciante. La s
 Posteriormente, llame de nuevo a la Create Quote API y solicite un recurso de cotización asociado con la `id` del pago entrante de la plataforma.
 
 <Tabs syncKey="lang">
-<TabItem label='Merchant' icon='seti:javascript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
   ```ts wrap
+  // Merchant
   const merchantQuote = await client.quote.create(
     {
       url: customerWalletAddress.resourceServer,
@@ -425,10 +421,7 @@ Posteriormente, llame de nuevo a la Create Quote API y solicite un recurso de co
       receiver: merchantIncomingPayment.id
     }
   )
-  ```
-</TabItem>
-<TabItem label='Platform' icon='seti:javascript'>
-  ```ts wrap
+  // Platform
   const platformQuote = await client.quote.create(
     {
       url: customerWalletAddress.resourceServer,
@@ -440,8 +433,8 @@ Posteriormente, llame de nuevo a la Create Quote API y solicite un recurso de co
       receiver: platformIncomingPayment.id
     }
   )
-  ```
-</TabItem>
+```
+ </TabItem>
 <TabItem label='Rust' icon='seti:rust'>
  ```rust wrap
  use open_payments::types::{QuoteRequest, QuoteMethod};
@@ -470,7 +463,7 @@ Posteriormente, llame de nuevo a la Create Quote API y solicite un recurso de co
  ```
  </TabItem>
  <TabItem label='Go' icon='seti:go'>
-  
+
   ```go wrap
   // Merchant
   merchantQuote, err := client.Quote.Create(context.TODO(), op.QuoteCreateParams{
@@ -529,6 +522,8 @@ Incluya lo siguiente en la solicitud, además de los parámetros requeridos:
 <Tabs syncKey="lang">
 <TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
   ```ts wrap
+  combinedQuoteAmount = '10000' // 9900 + 100
+
   const pendingCustomerOutgoingPaymentGrant = await client.grant.request(
     {
       url: customerWalletAddress.authServer
@@ -539,12 +534,12 @@ Incluya lo siguiente en la solicitud, además de los parámetros requeridos:
           {
             identifier: customerWalletAddress.id,
             type: 'outgoing-payment',
-            actions: ['read', 'create'],
+            actions: ['create'],
             limits: {
-              receiveAmount: {
+              debitAmount: {
                 assetCode: 'USD',
                 assetScale: 2,
-                value: '10000'
+                value: combinedQuoteAmount
               }
             }
           }
@@ -554,18 +549,18 @@ Incluya lo siguiente en la solicitud, además de los parámetros requeridos:
         start: ['redirect'],
         finish: {
           method: 'redirect',
-          uri: 'http://localhost:3344',
+          uri: 'https://paymentplatform.example/finish/{...}', // where to redirect the customer after they've completed interaction
           nonce: NONCE
         }
       }
     }
   )
   ```
-</TabItem>
+ </TabItem>
 <TabItem label='Rust' icon='seti:rust'>
  ```rust wrap
  use open_payments::types::{AccessTokenRequest, AccessItem, OutgoingPaymentAction, InteractRequest, InteractStart, InteractFinish, InteractFinishMethod, AccessLimits, Amount, GrantRequest};
- 
+
  let merchant_amount = match merchant_quote.debit_amount.as_ref() {
    Some(a) => &a.value,
    None => {
@@ -612,7 +607,7 @@ Incluya lo siguiente en la solicitud, además de los parámetros requeridos:
  </TabItem>
 
   <TabItem label='Go' icon='seti:go'>
-  
+
   ```go wrap
   combinedQuoteAmount := "10000" // merchantQuote.DebitAmount.Value + platformQuote.DebitAmount.Value
   limits := as.LimitsOutgoing{}
@@ -714,7 +709,7 @@ Incluya la `interact_ref` devuelta en los parámetros de consulta del URI de red
  </TabItem>
 
  <TabItem label='Go' icon='seti:go'>
-  
+
   ```go wrap
   customerOutgoingPaymentGrant, err := client.Grant.Continue(context.TODO(), op.GrantContinueParams{
     URL:         pendingCustomerOutgoingPaymentGrant.Continue.Uri,
@@ -739,9 +734,10 @@ Utilice los tókenes de acceso devueltos en el paso 5 para llamar a la <Badge te
 El propósito de estas llamadas consiste en solicitar la creación de un recurso de pago saliente en la cuenta de la billetera del consumidor: uno para el comerciante y otro para su plataforma. Incluya el `quoteId` correspondiente en cada solicitud.
 
 <Tabs syncKey="lang">
-<TabItem label='Merchant' icon='seti:javascript'>
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
   ```ts wrap
-  const customerOutgoingPayment = await client.outgoingPayment.create(
+  // Merchant
+  const customerOutgoingPaymentToMerchant = await client.outgoingPayment.create(
     {
       url: customerWalletAddress.resourceServer,
       accessToken: customerOutgoingPaymentGrant.access_token.value
@@ -751,11 +747,8 @@ El propósito de estas llamadas consiste en solicitar la creación de un recurso
       quoteId: merchantQuote.id
     }
   )
-  ```
-</TabItem>
-<TabItem label='Platform' icon='seti:javascript'>
-  ```ts wrap
-  const customerOutgoingPayment = await client.outgoingPayment.create(
+  // Platform
+  const customerOutgoingPaymentToPlatform = await client.outgoingPayment.create(
     {
       url: customerWalletAddress.resourceServer,
       accessToken: customerOutgoingPaymentGrant.access_token.value
@@ -765,8 +758,8 @@ El propósito de estas llamadas consiste en solicitar la creación de un recurso
       quoteId: platformQuote.id
     }
   )
-  ```
-</TabItem>
+```
+ </TabItem>
 <TabItem label='Rust' icon='seti:rust'>
  ```rust wrap
  use open_payments::types::OutgoingPaymentRequest;
@@ -796,7 +789,7 @@ El propósito de estas llamadas consiste en solicitar la creación de un recurso
  </TabItem>
 
   <TabItem label='Go' icon='seti:go'>
-  
+
   ```go wrap
   // Merchant
   var merchantOutgoingPayload rs.CreateOutgoingPaymentRequest
@@ -833,3 +826,34 @@ El propósito de estas llamadas consiste en solicitar la creación de un recurso
   ```
   </TabItem>
 </Tabs>
+
+<details>
+<summary>Ejemplo de respuesta</summary>
+El siguiente ejemplo muestra una respuesta cuando se crea un recurso de pago saliente en la cuenta del consumidor para el comerciante. Se devolverá una respuesta similar cuando se cree un recurso de pago saliente para usted, como proveedor de billetera.
+
+```json wrap
+{
+  "id": "https://cloudninebank.example.com/outgoing-payments/{...}", // url identifying the outgoing payment
+  "walletAddress": "https://cloudninebank.example.com/customer",
+  "receiver": "https://happylifebank.example.com/incoming-payments/{...}", // url of the incoming payment being paid
+  "debitAmount": {
+    "value": "9900",
+    "assetCode": "USD",
+    "assetScale": 2
+  },
+  "receiveAmount": {
+    "value": "9900",
+    "assetCode": "USD",
+    "assetScale": 2
+  },
+  "sentAmount": {
+    "value": "0",
+    "assetCode": "USD",
+    "assetScale": 2
+  },
+  "createdAt": "2022-03-12T23:20:54.52Z"
+}
+```
+
+</details>
+````

--- a/docs/src/content/docs/guides/accept-otp-online-purchase.mdx
+++ b/docs/src/content/docs/guides/accept-otp-online-purchase.mdx
@@ -237,7 +237,7 @@ Remember that the full amount of the customer's purchase is $1,400 MXN.
   <TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
 
 ```ts wrap
-const retailerIncomingPayment = await.client.incomingPayment.create(
+const retailerIncomingPayment = await client.incomingPayment.create(
   {
     url: retailerWalletAddress.resourceServer,
     accessToken: retailerIncomingPaymentGrant.access_token.value

--- a/docs/src/content/docs/guides/onetime-remittance-fixed-debit.mdx
+++ b/docs/src/content/docs/guides/onetime-remittance-fixed-debit.mdx
@@ -155,12 +155,12 @@ This call obtains an access token that allows your app to request that an incomi
         access: [
           {
             type: "incoming-payment",
-            actions: ["create"],
-          },
-        ],
-      },
-    },
-  );
+            actions: ["create"]
+          }
+        ]
+      }
+    }
+  )
   ```
  </TabItem>
  <TabItem label='Rust' icon='seti:rust'>
@@ -249,7 +249,7 @@ This call requests an incoming payment resource be created on the recipient's wa
     },
     {
       walletAddress: recipientWalletAddress.id
-    },
+    }
   )
 ```
  </TabItem>
@@ -558,7 +558,7 @@ Outgoing payments require an interactive grant. This type of grant will obtain t
               debitAmount: {
                 assetCode: 'USD',
                 assetScale: 2,
-                value: '10000', 
+                value: '10000'
               }
             }
           }

--- a/docs/src/content/docs/guides/onetime-remittance-fixed-receive.mdx
+++ b/docs/src/content/docs/guides/onetime-remittance-fixed-receive.mdx
@@ -159,10 +159,10 @@ This call obtains an access token that allows your app to request an incoming pa
           {
             type: 'incoming-payment',
             actions: ['create']
-          },
-        ],
-      },
-    },
+          }
+        ]
+      }
+    }
   );
   ```
   </TabItem>
@@ -252,8 +252,8 @@ This call requests an incoming payment resource be created on the recipient's wa
       accessToken: recipientIncomingPaymentGrant.access_token.value
     },
     {
-      walletAddress: recipientWalletAddress.id,
-    },
+      walletAddress: recipientWalletAddress.id
+    }
   )
   ```
   </TabItem>

--- a/docs/src/content/docs/guides/outgoing-grant-future-payments.mdx
+++ b/docs/src/content/docs/guides/outgoing-grant-future-payments.mdx
@@ -102,7 +102,7 @@ Remember, your user wants to send payments of up to $100 CAD a month for three m
   ```ts
   const grant = await client.grant.request(
     {
-      url: userWalletAddress.authServer,
+      url: userWalletAddress.authServer
     },
     {
       access_token: {
@@ -112,15 +112,15 @@ Remember, your user wants to send payments of up to $100 CAD a month for three m
             type: 'outgoing-payment',
             actions: ['read', 'create'],
             limits: {
-              interval: 'R3/2025-05-20T13:00:00Z/P1M'
+              interval: 'R3/2025-05-20T13:00:00Z/P1M',
               debitAmount: {
                 assetCode: 'CAD',
                 assetScale: 2,
-                value: '10000',
-              },
-            },
-          },
-        ],
+                value: '10000'
+              }
+            }
+          }
+        ]
       },
       client: userWalletAddress.id,
       interact: {
@@ -128,10 +128,10 @@ Remember, your user wants to send payments of up to $100 CAD a month for three m
         finish: {
           method: 'redirect',
           uri: 'https://paymentplatform.example/finish/{...}', // where to redirect the user to after they've completed the interaction
-          nonce: NONCE,
-        },
-      },
-    },
+          nonce: NONCE
+        }
+      }
+    }
   );
   ```
  </TabItem>
@@ -273,12 +273,12 @@ Include the `interact_ref` returned in the redirect URI's query parameters.
   ```ts wrap
   const userOutgoingPaymentGrant = await client.grant.continue(
     {
-      accessToken: pendingUserOutgoingPaymentGrant.continue.acces_token.value,
-      url: pendingUserOutgoingPaymentGrant.continue.uri,
+      accessToken: pendingUserOutgoingPaymentGrant.continue.access_token.value,
+      url: pendingUserOutgoingPaymentGrant.continue.uri
     },
     {
-      interact_ref: interactRef,
-    },
+      interact_ref: interactRef
+    }
   );
   ```
   </TabItem>
@@ -330,7 +330,7 @@ A successful response provides your app with an access token. Now your app can i
         {
           "type": "outgoing-payment",
           "actions": ["create", "read"],
-          "identifier": "https://cloudninebank.example.com/user",
+          "identifier": "https://cloudninebank.example.com/user"
         }
       ]
     },

--- a/docs/src/content/docs/guides/recurring-remittance-fixed-debit.mdx
+++ b/docs/src/content/docs/guides/recurring-remittance-fixed-debit.mdx
@@ -148,11 +148,11 @@ This call obtains an access token that allows your app to request an incoming pa
         access: [
           {
             type: 'incoming-payment',
-            actions: ['create'],
-          },
-        ],
-      },
-    },
+            actions: ['create']
+          }
+        ]
+      }
+    }
   );
   ```
   </TabItem>
@@ -227,8 +227,8 @@ This call requests an incoming payment resource be created on the recipient's wa
       accessToken: recipientIncomingPaymentGrant.access_token.value
     },
     {
-      walletAddress: recipientWalletAddress.id,
-    },
+      walletAddress: recipientWalletAddress.id
+    }
   )
   ```
   </TabItem>
@@ -521,7 +521,7 @@ Use the access token returned in the outgoing payment grant continuation respons
         assetCode: 'USD',
         assetScale: 2,
         value: '20000'
-      },
+      }
     }
   )
   ```

--- a/docs/src/content/docs/guides/recurring-remittance-fixed-receive.mdx
+++ b/docs/src/content/docs/guides/recurring-remittance-fixed-receive.mdx
@@ -168,7 +168,7 @@ Outgoing payments require an interactive grant, which the sender approves once. 
               receiveAmount: {
                 assetCode: 'MXN',
                 assetScale: 2,
-                value: '400000', 
+                value: '400000'
               }
             }
           }
@@ -379,11 +379,11 @@ This call obtains an access token that allows your app to request an incoming pa
         access: [
           {
             type: 'incoming-payment',
-            actions: ['create'],
-          },
-        ],
-      },
-    },
+            actions: ['create']
+          }
+        ]
+      }
+    }
   );
   ```
   </TabItem>
@@ -455,8 +455,8 @@ This call requests an incoming payment resource be created on the recipient's wa
       accessToken: recipientIncomingPaymentGrant.access_token.value
     },
     {
-      walletAddress: recipientWalletAddress.id,
-    },
+      walletAddress: recipientWalletAddress.id
+    }
   )
   ```
   </TabItem>
@@ -682,7 +682,7 @@ Use the access token returned in the outgoing payment grant continuation respons
     },
     {
       walletAddress: senderWalletAddress.id,
-      quoteId: senderQuote.id,
+      quoteId: senderQuote.id
     }
   )
   ```

--- a/docs/src/content/docs/guides/recurring-subscription-incoming-amount.mdx
+++ b/docs/src/content/docs/guides/recurring-subscription-incoming-amount.mdx
@@ -148,11 +148,11 @@ This call obtains an access token that allows you to request that an incoming pa
         access: [
           {
             type: "incoming-payment",
-            actions: ["create"],
-          },
-        ],
-      },
-    },
+            actions: ["create"]
+          }
+        ]
+      }
+    }
   );
 ```
 </TabItem>
@@ -232,8 +232,8 @@ This call requests an incoming payment resource be created on the service provid
         value: '1500',  // The amount the service provider expects to receive in the first payment
         assetCode: 'USD',
         assetScale: 2
-      },
-    },
+      }
+    }
   )
 ```
 </TabItem>
@@ -395,7 +395,7 @@ The request must contain the `receiver`, which is the `id` of the service provid
     {
       method: 'ilp',
       walletAddress: customerWalletAddress.id,
-      receiver: serviceProviderIncomingPayment.id,
+      receiver: serviceProviderIncomingPayment.id
     }
   )
 ```
@@ -486,7 +486,7 @@ For recurring payments, include the `interval` property to specify how often the
               debitAmount: {
                 assetCode: 'USD',
                 assetScale: 2,
-                value: '1500',
+                value: '1500'
               },
               interval: 'R12/2025-10-14T00:03:00Z/P1M'
             }

--- a/docs/src/content/docs/guides/split-payments.mdx
+++ b/docs/src/content/docs/guides/split-payments.mdx
@@ -145,11 +145,11 @@ If you and the merchant use the same account servicing entity, and as a result, 
         access: [
           {
             type: "incoming-payment",
-            actions: ["create"],
-          },
-        ],
-      },
-    },
+            actions: ["create"]
+          }
+        ]
+      }
+    }
   );
   // Platform
   const platformIncomingPaymentGrant = await client.grant.request(
@@ -161,11 +161,11 @@ If you and the merchant use the same account servicing entity, and as a result, 
         access: [
           {
             type: "incoming-payment",
-            actions: ["create"],
-          },
-        ],
-      },
-    },
+            actions: ["create"]
+          }
+        ]
+      }
+    }
   );
   ```
  </TabItem>
@@ -275,8 +275,8 @@ Remember that the merchant is receiving 99% of the payment (\$99.00 or `9900`) w
         value: '9900',
         assetCode: 'USD',
         assetScale: 2
-      },
-    },
+      }
+    }
   )
   // Platform
   const platformIncomingPayment = await client.incomingPayment.create(
@@ -290,8 +290,8 @@ Remember that the merchant is receiving 99% of the payment (\$99.00 or `9900`) w
         value: '100',
         assetCode: 'USD',
         assetScale: 2
-      },
-    },
+      }
+    }
   )
 ```
 </TabItem>
@@ -648,7 +648,7 @@ This call obtains an access token that allows your platform to request outgoing 
               debitAmount: {
                 assetCode: 'USD',
                 assetScale: 2,
-                value: combinedQuoteAmount,
+                value: combinedQuoteAmount
               }
             }
           }


### PR DESCRIPTION
Addresses #748 

Sync JavaScript/TypeScript examples in Spanish guides to match the English versions.

**Description of changes**

**Required**

- [ ] Used LinkOut component on external links
- [x] Reviewed Vale errors and made changes where appropriate
- [x] Ran Prettier
- [x] Previewed updates in Netlify
- [ ] Received SME and/or peer approval if updates are significant
- [x] Included a "fixes #" comment

**Conditional**

- [ ] Ensured sequence diagrams follow our style guide
- [x] Included code samples where appropriate
- [ ] Updated related READMEs