### PR TITLE
docs: add feedback widget for docs pages (fixes DOCSDEV-4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,3 +124,6 @@ styles/write-good/TooWordy.yml
 styles/write-good/Weasel.yml
 .vale.ini
 vale
+
+# Local Netlify folder
+.netlify

--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,3 +1,8 @@
 # Local direct-submit config for Netlify dev.
-GITHUB_TOKEN=
+# GitHub App (installation must have "Issues: write" on interledger/open-payments-docs-feedback)
+GITHUB_APP_ID=
+GITHUB_APP_INSTALLATION_ID=
+# Either set PEM inline (Netlify: use literal \n for newlines) or point to a local file
+GITHUB_APP_PRIVATE_KEY=
+GITHUB_APP_PRIVATE_KEY_PATH=
 PUBLIC_FEEDBACK_FUNCTION_URL=/.netlify/functions/feedback

--- a/docs/.env.example
+++ b/docs/.env.example
@@ -1,0 +1,3 @@
+# Local direct-submit config for Netlify dev.
+GITHUB_TOKEN=
+PUBLIC_FEEDBACK_FUNCTION_URL=/.netlify/functions/feedback

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -19,3 +19,5 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+.netlify

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -17,6 +17,10 @@ pnpm-debug.log*
 .env
 .env.production
 
+# GitHub App key (local dev only; never commit)
+.github-app-private-key.pem
+*.pem
+
 # macOS-specific files
 .DS_Store
 

--- a/docs/README_FEEDBACK_INTEGRATION.md
+++ b/docs/README_FEEDBACK_INTEGRATION.md
@@ -1,0 +1,17 @@
+# Feedback Widget
+
+The docs footer can either:
+
+- open a prefilled issue in `interledger/open-payments-docs-feedback`
+- post directly to GitHub through `docs/netlify/functions/feedback.ts`
+
+`openpayments.dev` is a GitHub Pages deploy, so production uses the issue-form fallback
+unless you point `PUBLIC_FEEDBACK_FUNCTION_URL` at another hosted endpoint.
+
+## Local dev
+
+1. Copy `docs/.env.example` to `docs/.env`.
+2. Run `pnpm dev:netlify` from `docs/`, or `pnpm --filter docs dev:netlify` from the repo root.
+3. Open the Netlify URL shown as `Local dev server ready`.
+
+Plain `pnpm start` only exercises the fallback path.

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -1,3 +1,5 @@
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { defineConfig } from 'astro/config'
 import starlight from '@astrojs/starlight'
 import starlightOpenAPI from 'starlight-openapi'
@@ -5,6 +7,32 @@ import starlightLinksValidator from 'starlight-links-validator'
 import starlightFullViewMode from 'starlight-fullview-mode'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
+import { loadEnv } from 'vite'
+
+const docsRoot = path.dirname(fileURLToPath(import.meta.url))
+const envFromFile = loadEnv(
+  process.env.NODE_ENV === 'production' ? 'production' : 'development',
+  docsRoot,
+  ''
+)
+
+const isNetlifyDev =
+  process.env.NETLIFY_DEV === 'true' || process.env.NETLIFY_DEV === '1'
+
+const netlifyDevFunctionsProxyTarget = (() => {
+  const raw =
+    process.env.URL ||
+    process.env.DEPLOY_URL ||
+    envFromFile.NETLIFY_FUNCTIONS_PROXY_TARGET
+  if (!raw) {
+    return null
+  }
+  try {
+    return new URL(raw).origin
+  } catch {
+    return null
+  }
+})()
 
 // https://astro.build/config
 export default defineConfig({
@@ -31,7 +59,8 @@ export default defineConfig({
       ],
       components: {
         Header: './src/components/Header.astro',
-        PageSidebar: './src/components/PageSidebar.astro'
+        PageSidebar: './src/components/PageSidebar.astro',
+        Footer: './src/components/Footer.astro'
       },
       customCss: [
         './node_modules/@interledger/docs-design-system/src/styles/teal-theme.css',
@@ -556,6 +585,15 @@ export default defineConfig({
     '/sdk/grant-create': '/sdk/grant-create-incoming'
   },
   server: {
-    port: 1104
+    port: 1104,
+    ...(isNetlifyDev &&
+      netlifyDevFunctionsProxyTarget && {
+        proxy: {
+          '/.netlify/functions': {
+            target: netlifyDevFunctionsProxyTarget,
+            changeOrigin: true
+          }
+        }
+      })
   }
 })

--- a/docs/eslint.config.js
+++ b/docs/eslint.config.js
@@ -14,7 +14,14 @@ export default defineConfig([
   },
   tseslint.configs.recommended,
   eslintPluginAstro.configs.recommended,
-  globalIgnores(['dist', '.astro', 'node_modules', 'public', '**/*.min.js']),
+  globalIgnores([
+    'dist',
+    '.astro',
+    '.netlify',
+    'node_modules',
+    'public',
+    '**/*.min.js'
+  ]),
   {
     rules: {
       'no-console': 'error',

--- a/docs/netlify.toml
+++ b/docs/netlify.toml
@@ -1,0 +1,10 @@
+[build]
+  command = "pnpm --dir docs build"
+  publish = "docs/dist"
+
+[functions]
+  directory = "docs/netlify/functions"
+
+[dev]
+  command = "pnpm exec astro dev --host --port 1104 --strictPort"
+  targetPort = 1104

--- a/docs/netlify/functions/feedback.ts
+++ b/docs/netlify/functions/feedback.ts
@@ -58,7 +58,8 @@ export const handler = async (event: NetlifyEvent) => {
     })
   }
 
-  const githubToken = process.env.GITHUB_TOKEN || readLocalEnvVar('GITHUB_TOKEN')
+  const githubToken =
+    process.env.GITHUB_TOKEN || readLocalEnvVar('GITHUB_TOKEN')
 
   if (!githubToken) {
     return createResponse(500, {

--- a/docs/netlify/functions/feedback.ts
+++ b/docs/netlify/functions/feedback.ts
@@ -102,8 +102,7 @@ const readLocalEnvVar = (name: string) => getLocalEnvFromDisk()?.map.get(name)
 
 const getEnv = (name: string) => process.env[name] || readLocalEnvVar(name)
 
-const normalizePrivateKey = (raw: string) =>
-  raw.trim().replace(/\\n/g, '\n')
+const normalizePrivateKey = (raw: string) => raw.trim().replace(/\\n/g, '\n')
 
 const loadPrivateKeyPem = (): string | undefined => {
   const inline = getEnv('GITHUB_APP_PRIVATE_KEY')
@@ -132,9 +131,7 @@ const loadPrivateKeyPem = (): string | undefined => {
 
   for (const base of bases) {
     try {
-      return normalizePrivateKey(
-        readFileSync(path.join(base, keyPath), 'utf8')
-      )
+      return normalizePrivateKey(readFileSync(path.join(base, keyPath), 'utf8'))
     } catch {
       continue
     }
@@ -266,22 +263,19 @@ ${message || '_No additional feedback provided_'}
 ---
 _Submitted via feedback widget on ${new Date().toISOString()}_`
 
-  const response = await fetch(
-    `${GITHUB_API}/repos/${GITHUB_REPO}/issues`,
-    {
-      method: 'POST',
-      headers: githubHeaders(`Bearer ${tokenResult.token}`),
-      body: JSON.stringify({
-        title: issueTitle,
-        body: issueBody,
-        labels: [
-          'feedback',
-          'docs',
-          type === 'yes' ? 'feedback-positive' : 'feedback-negative'
-        ]
-      })
-    }
-  )
+  const response = await fetch(`${GITHUB_API}/repos/${GITHUB_REPO}/issues`, {
+    method: 'POST',
+    headers: githubHeaders(`Bearer ${tokenResult.token}`),
+    body: JSON.stringify({
+      title: issueTitle,
+      body: issueBody,
+      labels: [
+        'feedback',
+        'docs',
+        type === 'yes' ? 'feedback-positive' : 'feedback-negative'
+      ]
+    })
+  })
 
   if (!response.ok) {
     return createResponse(response.status, {

--- a/docs/netlify/functions/feedback.ts
+++ b/docs/netlify/functions/feedback.ts
@@ -1,4 +1,4 @@
-import { createSign } from 'node:crypto'
+import { createPrivateKey, sign } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
@@ -47,17 +47,20 @@ const parseEnvFileContent = (content: string) => {
   return map
 }
 
-/** Netlify runs functions with an arbitrary cwd; walk up to find docs/.env or repo .env */
-const listEnvFileCandidates = (): string[] => {
-  const seen = new Set<string>()
+/**
+ * Netlify functions often have an unexpected cwd. Walk ancestors and try both
+ * each directory and its `docs/` subfolder (monorepo layout).
+ */
+const walkSearchBases = (): string[] => {
   const out: string[] = []
+  const seen = new Set<string>()
   let dir = process.cwd()
   for (let i = 0; i < 12; i++) {
-    for (const rel of ['.env', path.join('docs', '.env')]) {
-      const resolved = path.resolve(dir, rel)
-      if (!seen.has(resolved)) {
-        seen.add(resolved)
-        out.push(resolved)
+    for (const base of [dir, path.join(dir, 'docs')]) {
+      const normalized = path.normalize(base)
+      if (!seen.has(normalized)) {
+        seen.add(normalized)
+        out.push(normalized)
       }
     }
     const parent = path.dirname(dir)
@@ -68,6 +71,9 @@ const listEnvFileCandidates = (): string[] => {
   }
   return out
 }
+
+const listEnvFileCandidates = (): string[] =>
+  walkSearchBases().map((base) => path.resolve(base, '.env'))
 
 type LocalEnvCache = { map: Map<string, string>; baseDir: string } | null
 let localEnvCache: LocalEnvCache | undefined
@@ -118,27 +124,16 @@ const loadPrivateKeyPem = (): string | undefined => {
     }
   }
 
-  const roots = new Set<string>()
+  const bases = new Set(walkSearchBases())
   const local = getLocalEnvFromDisk()
   if (local?.baseDir) {
-    roots.add(local.baseDir)
-  }
-  roots.add(process.cwd())
-  roots.add(path.join(process.cwd(), 'docs'))
-  let walkDir = process.cwd()
-  for (let i = 0; i < 12; i++) {
-    roots.add(path.join(walkDir, 'docs'))
-    const parent = path.dirname(walkDir)
-    if (parent === walkDir) {
-      break
-    }
-    walkDir = parent
+    bases.add(path.normalize(local.baseDir))
   }
 
-  for (const root of roots) {
+  for (const base of bases) {
     try {
       return normalizePrivateKey(
-        readFileSync(path.join(root, keyPath), 'utf8')
+        readFileSync(path.join(base, keyPath), 'utf8')
       )
     } catch {
       continue
@@ -158,21 +153,18 @@ const createAppJwt = (appId: string, privateKeyPem: string) => {
   const exp = iat + 9 * 60
   const payload = { iat, exp, iss: appId }
   const unsigned = `${base64urlJson(header)}.${base64urlJson(payload)}`
-  const signer = createSign('RSA-SHA256')
-  signer.update(unsigned)
-  signer.end()
-  const signature = signer
-    .sign(privateKeyPem)
-    .toString('base64')
-    .replace(/=/g, '')
-    .replace(/\+/g, '-')
-    .replace(/\//g, '_')
+  const key = createPrivateKey(privateKeyPem)
+  const signature = sign(
+    'RSA-SHA256',
+    Buffer.from(unsigned, 'utf8'),
+    key
+  ).toString('base64url')
   return `${unsigned}.${signature}`
 }
 
-const githubHeaders = (auth: string, accept = 'application/vnd.github+json') => ({
-  Authorization: auth,
-  Accept: accept,
+const githubHeaders = (authorization: string) => ({
+  Authorization: authorization,
+  Accept: 'application/vnd.github+json',
   'Content-Type': 'application/json',
   'User-Agent': 'OpenPayments-Docs-Feedback-Widget',
   'X-GitHub-Api-Version': '2022-11-28'
@@ -191,12 +183,8 @@ const getInstallationAccessToken = async (
     }
   )
 
-  if (!response.ok) {
-    return { ok: false as const, status: response.status }
-  }
-
   const data = (await response.json()) as { token?: string }
-  if (!data.token) {
+  if (!response.ok || !data.token) {
     return { ok: false as const, status: response.status }
   }
 

--- a/docs/netlify/functions/feedback.ts
+++ b/docs/netlify/functions/feedback.ts
@@ -1,3 +1,4 @@
+import { createSign } from 'node:crypto'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
@@ -15,33 +16,191 @@ type NetlifyEvent = {
 }
 
 const GITHUB_REPO = 'interledger/open-payments-docs-feedback'
+const GITHUB_API = 'https://api.github.com'
 
-const readLocalEnvVar = (name: string) => {
-  try {
-    const envFile = readFileSync(path.join(process.cwd(), '.env'), 'utf8')
-    for (const line of envFile.split(/\r?\n/)) {
-      const trimmed = line.trim()
-      if (!trimmed || trimmed.startsWith('#')) {
-        continue
-      }
+const stripEnvValueQuotes = (value: string) => {
+  const t = value.trim()
+  if (
+    (t.startsWith('"') && t.endsWith('"')) ||
+    (t.startsWith("'") && t.endsWith("'"))
+  ) {
+    return t.slice(1, -1)
+  }
+  return t
+}
 
-      const separatorIndex = trimmed.indexOf('=')
-      if (separatorIndex === -1) {
-        continue
-      }
-
-      const key = trimmed.slice(0, separatorIndex).trim()
-      if (key !== name) {
-        continue
-      }
-
-      return trimmed.slice(separatorIndex + 1).trim()
+const parseEnvFileContent = (content: string) => {
+  const map = new Map<string, string>()
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) {
+      continue
     }
-  } catch {
+    const separatorIndex = trimmed.indexOf('=')
+    if (separatorIndex === -1) {
+      continue
+    }
+    const key = trimmed.slice(0, separatorIndex).trim()
+    const value = stripEnvValueQuotes(trimmed.slice(separatorIndex + 1))
+    map.set(key, value)
+  }
+  return map
+}
+
+/** Netlify runs functions with an arbitrary cwd; walk up to find docs/.env or repo .env */
+const listEnvFileCandidates = (): string[] => {
+  const seen = new Set<string>()
+  const out: string[] = []
+  let dir = process.cwd()
+  for (let i = 0; i < 12; i++) {
+    for (const rel of ['.env', path.join('docs', '.env')]) {
+      const resolved = path.resolve(dir, rel)
+      if (!seen.has(resolved)) {
+        seen.add(resolved)
+        out.push(resolved)
+      }
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+  return out
+}
+
+type LocalEnvCache = { map: Map<string, string>; baseDir: string } | null
+let localEnvCache: LocalEnvCache | undefined
+
+const getLocalEnvFromDisk = (): LocalEnvCache => {
+  if (localEnvCache !== undefined) {
+    return localEnvCache
+  }
+  for (const envPath of listEnvFileCandidates()) {
+    try {
+      const raw = readFileSync(envPath, 'utf8')
+      localEnvCache = {
+        map: parseEnvFileContent(raw),
+        baseDir: path.dirname(envPath)
+      }
+      return localEnvCache
+    } catch {
+      continue
+    }
+  }
+  localEnvCache = null
+  return localEnvCache
+}
+
+const readLocalEnvVar = (name: string) => getLocalEnvFromDisk()?.map.get(name)
+
+const getEnv = (name: string) => process.env[name] || readLocalEnvVar(name)
+
+const normalizePrivateKey = (raw: string) =>
+  raw.trim().replace(/\\n/g, '\n')
+
+const loadPrivateKeyPem = (): string | undefined => {
+  const inline = getEnv('GITHUB_APP_PRIVATE_KEY')
+  if (inline) {
+    return normalizePrivateKey(inline)
+  }
+
+  const keyPath = getEnv('GITHUB_APP_PRIVATE_KEY_PATH')
+  if (!keyPath) {
     return undefined
   }
 
+  if (path.isAbsolute(keyPath)) {
+    try {
+      return normalizePrivateKey(readFileSync(keyPath, 'utf8'))
+    } catch {
+      return undefined
+    }
+  }
+
+  const roots = new Set<string>()
+  const local = getLocalEnvFromDisk()
+  if (local?.baseDir) {
+    roots.add(local.baseDir)
+  }
+  roots.add(process.cwd())
+  roots.add(path.join(process.cwd(), 'docs'))
+  let walkDir = process.cwd()
+  for (let i = 0; i < 12; i++) {
+    roots.add(path.join(walkDir, 'docs'))
+    const parent = path.dirname(walkDir)
+    if (parent === walkDir) {
+      break
+    }
+    walkDir = parent
+  }
+
+  for (const root of roots) {
+    try {
+      return normalizePrivateKey(
+        readFileSync(path.join(root, keyPath), 'utf8')
+      )
+    } catch {
+      continue
+    }
+  }
+
   return undefined
+}
+
+const base64urlJson = (value: object) =>
+  Buffer.from(JSON.stringify(value)).toString('base64url')
+
+const createAppJwt = (appId: string, privateKeyPem: string) => {
+  const header = { alg: 'RS256', typ: 'JWT' }
+  const now = Math.floor(Date.now() / 1000)
+  const iat = now - 60
+  const exp = iat + 9 * 60
+  const payload = { iat, exp, iss: appId }
+  const unsigned = `${base64urlJson(header)}.${base64urlJson(payload)}`
+  const signer = createSign('RSA-SHA256')
+  signer.update(unsigned)
+  signer.end()
+  const signature = signer
+    .sign(privateKeyPem)
+    .toString('base64')
+    .replace(/=/g, '')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+  return `${unsigned}.${signature}`
+}
+
+const githubHeaders = (auth: string, accept = 'application/vnd.github+json') => ({
+  Authorization: auth,
+  Accept: accept,
+  'Content-Type': 'application/json',
+  'User-Agent': 'OpenPayments-Docs-Feedback-Widget',
+  'X-GitHub-Api-Version': '2022-11-28'
+})
+
+const getInstallationAccessToken = async (
+  appJwt: string,
+  installationId: string
+) => {
+  const response = await fetch(
+    `${GITHUB_API}/app/installations/${installationId}/access_tokens`,
+    {
+      method: 'POST',
+      headers: githubHeaders(`Bearer ${appJwt}`),
+      body: '{}'
+    }
+  )
+
+  if (!response.ok) {
+    return { ok: false as const, status: response.status }
+  }
+
+  const data = (await response.json()) as { token?: string }
+  if (!data.token) {
+    return { ok: false as const, status: response.status }
+  }
+
+  return { ok: true as const, token: data.token }
 }
 
 const createResponse = (statusCode: number, body: Record<string, unknown>) => ({
@@ -58,13 +217,14 @@ export const handler = async (event: NetlifyEvent) => {
     })
   }
 
-  const githubToken =
-    process.env.GITHUB_TOKEN || readLocalEnvVar('GITHUB_TOKEN')
+  const appId = getEnv('GITHUB_APP_ID')
+  const installationId = getEnv('GITHUB_APP_INSTALLATION_ID')
+  const privateKey = loadPrivateKeyPem()
 
-  if (!githubToken) {
+  if (!appId || !installationId || !privateKey) {
     return createResponse(500, {
       success: false,
-      error: 'GitHub token not configured'
+      error: 'GitHub App credentials not configured'
     })
   }
 
@@ -88,6 +248,24 @@ export const handler = async (event: NetlifyEvent) => {
     })
   }
 
+  let appJwt: string
+  try {
+    appJwt = createAppJwt(appId, privateKey)
+  } catch {
+    return createResponse(500, {
+      success: false,
+      error: 'Could not sign GitHub App JWT'
+    })
+  }
+
+  const tokenResult = await getInstallationAccessToken(appJwt, installationId)
+  if (!tokenResult.ok) {
+    return createResponse(502, {
+      success: false,
+      error: 'Could not obtain GitHub installation token'
+    })
+  }
+
   const emoji = type === 'yes' ? '🙂' : '🙁'
   const sentiment = type === 'yes' ? 'Positive' : 'Negative'
   const issueTitle = `[Feedback] ${emoji} ${page}`
@@ -101,15 +279,10 @@ ${message || '_No additional feedback provided_'}
 _Submitted via feedback widget on ${new Date().toISOString()}_`
 
   const response = await fetch(
-    `https://api.github.com/repos/${GITHUB_REPO}/issues`,
+    `${GITHUB_API}/repos/${GITHUB_REPO}/issues`,
     {
       method: 'POST',
-      headers: {
-        Authorization: `token ${githubToken}`,
-        Accept: 'application/vnd.github.v3+json',
-        'Content-Type': 'application/json',
-        'User-Agent': 'OpenPayments-Docs-Feedback-Widget'
-      },
+      headers: githubHeaders(`Bearer ${tokenResult.token}`),
       body: JSON.stringify({
         title: issueTitle,
         body: issueBody,

--- a/docs/netlify/functions/feedback.ts
+++ b/docs/netlify/functions/feedback.ts
@@ -88,7 +88,7 @@ export const handler = async (event: NetlifyEvent) => {
     })
   }
 
-  const emoji = type === 'yes' ? '👍' : '👎'
+  const emoji = type === 'yes' ? '🙂' : '🙁'
   const sentiment = type === 'yes' ? 'Positive' : 'Negative'
   const issueTitle = `[Feedback] ${emoji} ${page}`
   const issueBody = `**Page:** ${page}

--- a/docs/netlify/functions/feedback.ts
+++ b/docs/netlify/functions/feedback.ts
@@ -1,0 +1,141 @@
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+type FeedbackChoice = 'yes' | 'no'
+
+type FeedbackRequest = {
+  type?: FeedbackChoice
+  page?: string
+  message?: string
+}
+
+type NetlifyEvent = {
+  httpMethod: string
+  body: string | null
+}
+
+const GITHUB_REPO = 'interledger/open-payments-docs-feedback'
+
+const readLocalEnvVar = (name: string) => {
+  try {
+    const envFile = readFileSync(path.join(process.cwd(), '.env'), 'utf8')
+    for (const line of envFile.split(/\r?\n/)) {
+      const trimmed = line.trim()
+      if (!trimmed || trimmed.startsWith('#')) {
+        continue
+      }
+
+      const separatorIndex = trimmed.indexOf('=')
+      if (separatorIndex === -1) {
+        continue
+      }
+
+      const key = trimmed.slice(0, separatorIndex).trim()
+      if (key !== name) {
+        continue
+      }
+
+      return trimmed.slice(separatorIndex + 1).trim()
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
+const createResponse = (statusCode: number, body: Record<string, unknown>) => ({
+  statusCode,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body)
+})
+
+export const handler = async (event: NetlifyEvent) => {
+  if (event.httpMethod !== 'POST') {
+    return createResponse(405, {
+      success: false,
+      error: 'Method not allowed'
+    })
+  }
+
+  const githubToken = process.env.GITHUB_TOKEN || readLocalEnvVar('GITHUB_TOKEN')
+
+  if (!githubToken) {
+    return createResponse(500, {
+      success: false,
+      error: 'GitHub token not configured'
+    })
+  }
+
+  let payload: FeedbackRequest
+
+  try {
+    payload = JSON.parse(event.body || '{}') as FeedbackRequest
+  } catch {
+    return createResponse(400, {
+      success: false,
+      error: 'Invalid JSON payload'
+    })
+  }
+
+  const { type, page, message } = payload
+
+  if ((type !== 'yes' && type !== 'no') || !page) {
+    return createResponse(400, {
+      success: false,
+      error: 'Missing required feedback fields'
+    })
+  }
+
+  const emoji = type === 'yes' ? '👍' : '👎'
+  const sentiment = type === 'yes' ? 'Positive' : 'Negative'
+  const issueTitle = `[Feedback] ${emoji} ${page}`
+  const issueBody = `**Page:** ${page}
+**Feedback Type:** ${sentiment} ${emoji}
+**User Message:**
+
+${message || '_No additional feedback provided_'}
+
+---
+_Submitted via feedback widget on ${new Date().toISOString()}_`
+
+  const response = await fetch(
+    `https://api.github.com/repos/${GITHUB_REPO}/issues`,
+    {
+      method: 'POST',
+      headers: {
+        Authorization: `token ${githubToken}`,
+        Accept: 'application/vnd.github.v3+json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'OpenPayments-Docs-Feedback-Widget'
+      },
+      body: JSON.stringify({
+        title: issueTitle,
+        body: issueBody,
+        labels: [
+          'feedback',
+          'docs',
+          type === 'yes' ? 'feedback-positive' : 'feedback-negative'
+        ]
+      })
+    }
+  )
+
+  if (!response.ok) {
+    return createResponse(response.status, {
+      success: false,
+      error: 'GitHub API request failed'
+    })
+  }
+
+  const issue = (await response.json()) as {
+    html_url?: string
+    number?: number
+  }
+
+  return createResponse(200, {
+    success: true,
+    issueUrl: issue.html_url,
+    issueNumber: issue.number
+  })
+}

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "version": "0.0.1",
   "scripts": {
     "start": "astro dev",
-    "dev:netlify": "pnpm dlx netlify-cli@25.1.0 dev",
+    "dev:netlify": "pnpm --package=netlify-cli@25.1.0 dlx netlify dev",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "scripts": {
     "start": "astro dev",
+    "dev:netlify": "pnpm dlx netlify-cli@25.1.0 dev",
     "build": "astro build",
     "preview": "astro preview",
     "astro": "astro",
@@ -37,6 +38,7 @@
     "globals": "^17.2.0",
     "prettier": "3.8.1",
     "prettier-plugin-astro": "0.14.1",
-    "typescript-eslint": "^8.54.0"
+    "typescript-eslint": "^8.54.0",
+    "vite": "^6.4.1"
   }
 }

--- a/docs/src/components/FeedbackWidget.astro
+++ b/docs/src/components/FeedbackWidget.astro
@@ -280,8 +280,7 @@ const functionUrl =
     const submitErrorDefault =
       widget.dataset.submitError ||
       'Could not submit feedback. Check your connection and try again.'
-    const feedbackError =
-      widget.querySelector<HTMLElement>('#feedback-error')
+    const feedbackError = widget.querySelector<HTMLElement>('#feedback-error')
 
     let selectedFeedback: FeedbackChoice | null = null
 

--- a/docs/src/components/FeedbackWidget.astro
+++ b/docs/src/components/FeedbackWidget.astro
@@ -10,7 +10,9 @@ const translations = {
     improve: 'Help us improve',
     improvePlaceholder: 'What can we improve?',
     submit: 'Submit',
-    submitting: 'Submitting...'
+    submitting: 'Submitting...',
+    submitError:
+      'Could not submit feedback. Check your connection and try again.'
   },
   es: {
     question: '¿Fue útil esta página?',
@@ -20,7 +22,9 @@ const translations = {
     improve: 'Ayúdanos a mejorar',
     improvePlaceholder: '¿Qué podemos mejorar?',
     submit: 'Enviar',
-    submitting: 'Enviando...'
+    submitting: 'Enviando...',
+    submitError:
+      'No se pudo enviar el comentario. Comprueba tu conexión e inténtalo de nuevo.'
   }
 }
 
@@ -36,6 +40,7 @@ const functionUrl =
   id="feedback-widget"
   data-function-url={functionUrl}
   data-issue-repo="interledger/open-payments-docs-feedback"
+  data-submit-error={t.submitError}
 >
   <div class="feedback-question">
     <h3>{t.question}</h3>
@@ -98,6 +103,7 @@ const functionUrl =
   <div class="feedback-success hidden" id="feedback-success" aria-live="polite">
     <p>{t.thanks}</p>
   </div>
+  <div class="feedback-error hidden" id="feedback-error" role="alert"></div>
 </div>
 
 <style>
@@ -220,6 +226,15 @@ const functionUrl =
     text-align: center;
   }
 
+  .feedback-error {
+    margin-top: var(--sl-spacing-m, 1rem);
+    padding: var(--sl-spacing-s, 0.75rem);
+    border-radius: 0.375rem;
+    background: #fef2f2;
+    color: #b91c1c;
+    font-size: 0.875rem;
+  }
+
   .hidden {
     display: none;
   }
@@ -262,10 +277,31 @@ const functionUrl =
     const functionUrl = widget.dataset.functionUrl?.trim() || ''
     const issueRepo =
       widget.dataset.issueRepo || 'interledger/open-payments-docs-feedback'
+    const submitErrorDefault =
+      widget.dataset.submitError ||
+      'Could not submit feedback. Check your connection and try again.'
+    const feedbackError =
+      widget.querySelector<HTMLElement>('#feedback-error')
 
     let selectedFeedback: FeedbackChoice | null = null
 
+    const hideError = () => {
+      feedbackError?.classList.add('hidden')
+      if (feedbackError) {
+        feedbackError.textContent = ''
+      }
+    }
+
+    const showError = (message: string) => {
+      if (!feedbackError) {
+        return
+      }
+      feedbackError.textContent = message
+      feedbackError.classList.remove('hidden')
+    }
+
     const showSuccess = () => {
+      hideError()
       feedbackForm?.classList.add('hidden')
       feedbackSuccess?.classList.remove('hidden')
     }
@@ -323,6 +359,7 @@ ${message || '_No additional feedback provided_'}`
         }
 
         selectedFeedback = choice
+        hideError()
         feedbackQuestion?.classList.add('hidden')
         feedbackForm?.classList.remove('hidden')
         feedbackText?.focus()
@@ -349,8 +386,9 @@ ${message || '_No additional feedback provided_'}`
             return
           }
 
+          hideError()
           const controller = new AbortController()
-          const timeoutId = window.setTimeout(() => controller.abort(), 4000)
+          const timeoutId = window.setTimeout(() => controller.abort(), 25_000)
 
           const response = await fetch(functionUrl, {
             method: 'POST',
@@ -371,16 +409,25 @@ ${message || '_No additional feedback provided_'}`
           let result: { success?: boolean; error?: string } = {}
 
           if (rawResponse) {
-            result = JSON.parse(rawResponse) as {
-              success?: boolean
-              error?: string
+            try {
+              result = JSON.parse(rawResponse) as {
+                success?: boolean
+                error?: string
+              }
+            } catch {
+              result = {}
             }
           }
 
           if (!response.ok || !result.success) {
-            throw new Error(
-              result.error || `Request failed with status ${response.status}`
-            )
+            showError(result.error || submitErrorDefault)
+            track('feedback', {
+              type: selectedFeedback,
+              hasMessage: feedback.length > 0,
+              delivery: 'function-error',
+              status: response.status
+            })
+            return
           }
 
           showSuccess()
@@ -390,7 +437,12 @@ ${message || '_No additional feedback provided_'}`
             delivery: 'function'
           })
         } catch {
-          openIssueFallback(selectedFeedback, page, feedback)
+          showError(submitErrorDefault)
+          track('feedback', {
+            type: selectedFeedback!,
+            hasMessage: feedback.length > 0,
+            delivery: 'function-error'
+          })
         } finally {
           submitButton.disabled = false
           submitButton.textContent = originalLabel

--- a/docs/src/components/FeedbackWidget.astro
+++ b/docs/src/components/FeedbackWidget.astro
@@ -1,0 +1,401 @@
+---
+const { lang = 'en' } = Astro.props
+
+const translations = {
+  en: {
+    question: 'Was this page helpful?',
+    yes: 'Yes',
+    no: 'No',
+    thanks: 'Thanks for your feedback!',
+    improve: 'Help us improve',
+    improvePlaceholder: 'What can we improve?',
+    submit: 'Submit',
+    submitting: 'Submitting...'
+  },
+  es: {
+    question: '¿Fue útil esta página?',
+    yes: 'Sí',
+    no: 'No',
+    thanks: '¡Gracias por tu comentario!',
+    improve: 'Ayúdanos a mejorar',
+    improvePlaceholder: '¿Qué podemos mejorar?',
+    submit: 'Enviar',
+    submitting: 'Enviando...'
+  }
+}
+
+const t = translations[lang as keyof typeof translations] || translations.en
+const functionUrl =
+  typeof import.meta.env.PUBLIC_FEEDBACK_FUNCTION_URL === 'string'
+    ? import.meta.env.PUBLIC_FEEDBACK_FUNCTION_URL.trim()
+    : ''
+---
+
+<div
+  class="feedback-widget"
+  id="feedback-widget"
+  data-function-url={functionUrl}
+  data-issue-repo="interledger/open-payments-docs-feedback"
+>
+  <div class="feedback-question">
+    <h3>{t.question}</h3>
+    <div class="feedback-buttons">
+      <button
+        class="feedback-btn feedback-yes"
+        data-feedback="yes"
+        type="button"
+      >
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M10 1.5L12.5 6.5L18 7.5L14 11.5L15 17L10 14.5L5 17L6 11.5L2 7.5L7.5 6.5L10 1.5Z"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"></path>
+        </svg>
+        {t.yes}
+      </button>
+      <button class="feedback-btn feedback-no" data-feedback="no" type="button">
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 20 20"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 5L5 15M5 5L15 15"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"></path>
+        </svg>
+        {t.no}
+      </button>
+    </div>
+  </div>
+
+  <div class="feedback-form hidden" id="feedback-form">
+    <p class="feedback-thanks">{t.thanks}</p>
+    <label for="feedback-text">{t.improve}</label>
+    <textarea id="feedback-text" rows="4" placeholder={t.improvePlaceholder}
+    ></textarea>
+    <button
+      class="feedback-submit"
+      id="submit-feedback"
+      data-submitting={t.submitting}
+      type="button"
+    >
+      {t.submit}
+    </button>
+  </div>
+
+  <div class="feedback-success hidden" id="feedback-success" aria-live="polite">
+    <p>{t.thanks}</p>
+  </div>
+</div>
+
+<style>
+  .feedback-widget {
+    margin-top: var(--sl-spacing-2xl, 2rem);
+    padding: var(--sl-spacing-m, 1rem);
+    border-top: 1px solid var(--sl-color-hairline-shade, #e0e0e0);
+  }
+
+  .feedback-question h3 {
+    font-size: var(--sl-text-base, 1rem);
+    font-weight: 600;
+    margin: 0 0 var(--sl-spacing-s, 0.75rem) 0;
+    color: var(--sl-color-text, #333);
+  }
+
+  .feedback-buttons {
+    display: flex;
+    gap: var(--sl-spacing-xs, 0.5rem);
+  }
+
+  .feedback-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--sl-color-hairline-shade, #e0e0e0);
+    background: var(--sl-color-bg, white);
+    color: var(--sl-color-text, #333);
+    border-radius: 0.375rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    transition:
+      background-color 0.2s,
+      border-color 0.2s,
+      color 0.2s;
+  }
+
+  .feedback-btn:hover {
+    background: var(--sl-color-bg-nav, #f5f5f5);
+    border-color: var(--sl-color-text-accent, #0066cc);
+  }
+
+  .feedback-btn svg {
+    flex-shrink: 0;
+  }
+
+  .feedback-yes:hover {
+    color: #16a34a;
+    border-color: #16a34a;
+  }
+
+  .feedback-no:hover {
+    color: #dc2626;
+    border-color: #dc2626;
+  }
+
+  .feedback-form {
+    margin-top: var(--sl-spacing-m, 1rem);
+  }
+
+  .feedback-form label {
+    display: block;
+    margin-bottom: var(--sl-spacing-2xs, 0.25rem);
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--sl-color-text, #333);
+  }
+
+  .feedback-form textarea {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--sl-color-hairline-shade, #e0e0e0);
+    border-radius: 0.375rem;
+    font-family: inherit;
+    font-size: 0.875rem;
+    resize: vertical;
+    background: var(--sl-color-bg, white);
+    color: var(--sl-color-text, #333);
+  }
+
+  .feedback-form textarea:focus {
+    outline: none;
+    border-color: var(--sl-color-text-accent, #0066cc);
+    box-shadow: 0 0 0 3px rgba(0, 102, 204, 0.1);
+  }
+
+  .feedback-submit {
+    margin-top: var(--sl-spacing-xs, 0.5rem);
+    padding: 0.5rem 1rem;
+    background: var(--sl-color-text-accent, #0066cc);
+    color: white;
+    border: none;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    font-size: 0.875rem;
+    font-weight: 500;
+    transition: background-color 0.2s;
+  }
+
+  .feedback-submit:hover {
+    background: var(--sl-color-text-accent-high, #0052a3);
+  }
+
+  .feedback-submit:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+
+  .feedback-thanks {
+    color: #16a34a;
+    font-weight: 500;
+    margin-bottom: var(--sl-spacing-xs, 0.5rem);
+  }
+
+  .feedback-success {
+    color: #16a34a;
+    font-weight: 500;
+    padding: var(--sl-spacing-m, 1rem);
+    text-align: center;
+  }
+
+  .hidden {
+    display: none;
+  }
+</style>
+
+<script>
+  type FeedbackChoice = 'yes' | 'no'
+  type TrackPayload = Record<string, string | number | boolean>
+
+  const widget = document.getElementById('feedback-widget')
+
+  const track = (eventName: string, payload: TrackPayload) => {
+    const analytics = (
+      window as Window & {
+        umami?: {
+          track: (
+            trackedEventName: string,
+            trackedPayload?: TrackPayload
+          ) => void
+        }
+      }
+    ).umami
+
+    analytics?.track(eventName, payload)
+  }
+
+  if (widget instanceof HTMLElement) {
+    const feedbackQuestion =
+      widget.querySelector<HTMLElement>('.feedback-question')
+    const feedbackButtons = Array.from(
+      widget.querySelectorAll<HTMLButtonElement>('.feedback-btn')
+    )
+    const feedbackForm = widget.querySelector<HTMLElement>('#feedback-form')
+    const feedbackSuccess =
+      widget.querySelector<HTMLElement>('#feedback-success')
+    const feedbackText =
+      widget.querySelector<HTMLTextAreaElement>('#feedback-text')
+    const submitButton =
+      widget.querySelector<HTMLButtonElement>('#submit-feedback')
+    const functionUrl = widget.dataset.functionUrl?.trim() || ''
+    const issueRepo =
+      widget.dataset.issueRepo || 'interledger/open-payments-docs-feedback'
+
+    let selectedFeedback: FeedbackChoice | null = null
+
+    const showSuccess = () => {
+      feedbackForm?.classList.add('hidden')
+      feedbackSuccess?.classList.remove('hidden')
+    }
+
+    const createIssueUrl = (
+      feedbackType: FeedbackChoice,
+      page: string,
+      message: string
+    ) => {
+      const emoji = feedbackType === 'yes' ? '👍' : '👎'
+      const sentiment = feedbackType === 'yes' ? 'Positive' : 'Negative'
+      const issueUrl = new URL(`https://github.com/${issueRepo}/issues/new`)
+
+      issueUrl.searchParams.set('title', `[Feedback] ${emoji} ${page}`)
+      issueUrl.searchParams.set(
+        'body',
+        `**Page:** ${page}
+**Feedback Type:** ${sentiment} ${emoji}
+**User Message:**
+
+${message || '_No additional feedback provided_'}`
+      )
+      issueUrl.searchParams.set('labels', 'feedback,docs')
+
+      return issueUrl.toString()
+    }
+
+    const openIssueFallback = (
+      feedbackType: FeedbackChoice,
+      page: string,
+      message: string
+    ) => {
+      const issueUrl = createIssueUrl(feedbackType, page, message)
+      const openedWindow = window.open(issueUrl, '_blank', 'noopener')
+
+      if (!openedWindow) {
+        window.location.href = issueUrl
+        return
+      }
+
+      showSuccess()
+      track('feedback', {
+        type: feedbackType,
+        hasMessage: message.length > 0,
+        delivery: 'github-issue'
+      })
+    }
+
+    feedbackButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const choice = button.dataset.feedback
+
+        if (choice !== 'yes' && choice !== 'no') {
+          return
+        }
+
+        selectedFeedback = choice
+        feedbackQuestion?.classList.add('hidden')
+        feedbackForm?.classList.remove('hidden')
+        feedbackText?.focus()
+      })
+    })
+
+    if (submitButton instanceof HTMLButtonElement) {
+      submitButton.addEventListener('click', async () => {
+        if (!selectedFeedback) {
+          return
+        }
+
+        const feedback = feedbackText?.value.trim() || ''
+        const page = window.location.pathname
+        const originalLabel = submitButton.textContent
+
+        submitButton.disabled = true
+        submitButton.textContent =
+          submitButton.dataset.submitting || 'Submitting...'
+
+        try {
+          if (!functionUrl) {
+            openIssueFallback(selectedFeedback, page, feedback)
+            return
+          }
+
+          const controller = new AbortController()
+          const timeoutId = window.setTimeout(() => controller.abort(), 4000)
+
+          const response = await fetch(functionUrl, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+              type: selectedFeedback,
+              page,
+              message: feedback
+            }),
+            signal: controller.signal
+          })
+
+          const rawResponse = await response.text()
+          window.clearTimeout(timeoutId)
+
+          let result: { success?: boolean; error?: string } = {}
+
+          if (rawResponse) {
+            result = JSON.parse(rawResponse) as {
+              success?: boolean
+              error?: string
+            }
+          }
+
+          if (!response.ok || !result.success) {
+            throw new Error(
+              result.error || `Request failed with status ${response.status}`
+            )
+          }
+
+          showSuccess()
+          track('feedback', {
+            type: selectedFeedback,
+            hasMessage: feedback.length > 0,
+            delivery: 'function'
+          })
+        } catch {
+          openIssueFallback(selectedFeedback, page, feedback)
+        } finally {
+          submitButton.disabled = false
+          submitButton.textContent = originalLabel
+        }
+      })
+    }
+  }
+</script>

--- a/docs/src/components/Footer.astro
+++ b/docs/src/components/Footer.astro
@@ -1,0 +1,17 @@
+---
+import Default from '@astrojs/starlight/components/Footer.astro'
+import FeedbackWidget from './FeedbackWidget.astro'
+
+const lang = Astro.currentLocale === 'es' ? 'es' : 'en'
+const pathname = Astro.url.pathname
+const routeId = Astro.locals.starlightRoute?.id
+
+const normalizedPathname =
+  pathname !== '/' && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname
+const isIndexPage = normalizedPathname === '/' || normalizedPathname === '/es'
+const is404Page = routeId === '404'
+---
+
+{!isIndexPage && !is404Page && <FeedbackWidget lang={lang} />}
+
+<Default {...Astro.props}><slot /></Default>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,16 +31,16 @@ importers:
     dependencies:
       '@astrojs/markdown-remark':
         specifier: ^7.1.0
-        version: 7.1.0
+        version: 7.1.1
       '@astrojs/starlight':
         specifier: ^0.38.3
-        version: 0.38.3(astro@6.1.8)
+        version: 0.38.4(astro@6.1.9)
       '@interledger/docs-design-system':
         specifier: ^0.12.0
         version: 0.12.0
       astro:
         specifier: ^6.1.7
-        version: 6.1.8(typescript@5.9.3)
+        version: 6.1.9(typescript@5.9.3)
       katex:
         specifier: ^0.16.28
         version: 0.16.28
@@ -61,13 +61,13 @@ importers:
         version: 4.0.2
       starlight-fullview-mode:
         specifier: ^0.2.6
-        version: 0.2.6(@astrojs/starlight@0.38.3)
+        version: 0.2.6(@astrojs/starlight@0.38.4)
       starlight-links-validator:
         specifier: ^0.23.0
-        version: 0.23.0(@astrojs/starlight@0.38.3)(astro@6.1.8)
+        version: 0.23.0(@astrojs/starlight@0.38.4)(astro@6.1.9)
       starlight-openapi:
         specifier: ^0.24.0
-        version: 0.24.0(@astrojs/markdown-remark@7.1.0)(@astrojs/starlight@0.38.3)(astro@6.1.8)(openapi-types@12.1.3)
+        version: 0.24.0(@astrojs/markdown-remark@7.1.1)(@astrojs/starlight@0.38.4)(astro@6.1.9)(openapi-types@12.1.3)
     devDependencies:
       '@eslint/js':
         specifier: ^9.39.2
@@ -135,16 +135,16 @@ packages:
     resolution: {integrity: sha512-z97oYbdebO5aoWzuJ/8q5hLK232+17KcLZ7cJ8BCWk6+qNzVxn/gftC0KzMBUTD8WAaBkPpNSQK6PXLnNrZ0CA==}
     dev: false
 
-  /@astrojs/internal-helpers@0.8.0:
-    resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
+  /@astrojs/internal-helpers@0.9.0:
+    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
     dependencies:
       picomatch: 4.0.4
     dev: false
 
-  /@astrojs/markdown-remark@7.1.0:
-    resolution: {integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==}
+  /@astrojs/markdown-remark@7.1.1:
+    resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
     dependencies:
-      '@astrojs/internal-helpers': 0.8.0
+      '@astrojs/internal-helpers': 0.9.0
       '@astrojs/prism': 4.0.1
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -159,7 +159,7 @@ packages:
       remark-smartypants: 3.0.2
       retext-smartypants: 6.2.0
       shiki: 4.0.2
-      smol-toml: 1.6.1
+      smol-toml: 1.6.0
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -169,17 +169,17 @@ packages:
       - supports-color
     dev: false
 
-  /@astrojs/mdx@5.0.3(astro@6.1.8):
-    resolution: {integrity: sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg==}
+  /@astrojs/mdx@5.0.4(astro@6.1.9):
+    resolution: {integrity: sha512-tSbuuYueNODiFAFaME7pjHY5lOLoxBYJi1cKd6scw9+a4ZO7C7UGdafEoVAQvOV2eO8a6RaHSAJYGVPL1w8BPA==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       astro: ^6.0.0
     dependencies:
-      '@astrojs/markdown-remark': 7.1.0
+      '@astrojs/markdown-remark': 7.1.1
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.1.8(typescript@5.9.3)
-      es-module-lexer: 2.0.0
+      astro: 6.1.9(typescript@5.9.3)
+      es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
       piccolore: 0.1.3
@@ -208,20 +208,20 @@ packages:
       zod: 4.3.6
     dev: false
 
-  /@astrojs/starlight@0.38.3(astro@6.1.8):
-    resolution: {integrity: sha512-kDlJPlUDdQFWYmyFM2yUPo66yws7v067AEK+/rQjjoVyqehL3DabuOJuy6UJFFTFyGbHxYcBms/ITEgdW7tphw==}
+  /@astrojs/starlight@0.38.4(astro@6.1.9):
+    resolution: {integrity: sha512-TGFIr2aVC+gcZCPQzJOO4ZnA/yL3jRnsUDcKlVdEhxhxaOQnWr9lZ9MRScg9zU6uh3HVeZAmmjkLCdTlHdcaZA==}
     peerDependencies:
       astro: ^6.0.0
     dependencies:
-      '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.3(astro@6.1.8)
+      '@astrojs/markdown-remark': 7.1.1
+      '@astrojs/mdx': 5.0.4(astro@6.1.9)
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.1.8(typescript@5.9.3)
-      astro-expressive-code: 0.41.7(astro@6.1.8)
+      astro: 6.1.9(typescript@5.9.3)
+      astro-expressive-code: 0.41.7(astro@6.1.9)
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.2
@@ -240,7 +240,7 @@ packages:
       remark-directive: 3.0.0
       ultrahtml: 1.6.0
       unified: 11.0.5
-      unist-util-visit: 5.1.0
+      unist-util-visit: 5.0.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -308,7 +308,7 @@ packages:
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
     dependencies:
-      fontkitten: 1.0.3
+      fontkitten: 1.0.2
     dev: false
 
   /@chevrotain/cst-dts-gen@11.0.3:
@@ -384,12 +384,21 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /@emnapi/runtime@1.10.0:
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  /@emnapi/runtime@1.7.1:
+    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
     requiresBuild: true
     dependencies:
       tslib: 2.8.1
     dev: false
+    optional: true
+
+  /@esbuild/aix-ppc64@0.25.2:
+    resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/aix-ppc64@0.27.7:
@@ -398,6 +407,16 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-arm64@0.25.2:
+    resolution: {integrity: sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm64@0.27.7:
@@ -406,6 +425,16 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-arm@0.25.2:
+    resolution: {integrity: sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-arm@0.27.7:
@@ -414,6 +443,16 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/android-x64@0.25.2:
+    resolution: {integrity: sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/android-x64@0.27.7:
@@ -422,6 +461,16 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/darwin-arm64@0.25.2:
+    resolution: {integrity: sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-arm64@0.27.7:
@@ -430,6 +479,16 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/darwin-x64@0.25.2:
+    resolution: {integrity: sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/darwin-x64@0.27.7:
@@ -438,6 +497,16 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/freebsd-arm64@0.25.2:
+    resolution: {integrity: sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-arm64@0.27.7:
@@ -446,6 +515,16 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/freebsd-x64@0.25.2:
+    resolution: {integrity: sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/freebsd-x64@0.27.7:
@@ -454,6 +533,16 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-arm64@0.25.2:
+    resolution: {integrity: sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm64@0.27.7:
@@ -462,6 +551,16 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-arm@0.25.2:
+    resolution: {integrity: sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-arm@0.27.7:
@@ -470,6 +569,16 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-ia32@0.25.2:
+    resolution: {integrity: sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ia32@0.27.7:
@@ -478,6 +587,16 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-loong64@0.25.2:
+    resolution: {integrity: sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-loong64@0.27.7:
@@ -486,6 +605,16 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-mips64el@0.25.2:
+    resolution: {integrity: sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-mips64el@0.27.7:
@@ -494,6 +623,16 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-ppc64@0.25.2:
+    resolution: {integrity: sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-ppc64@0.27.7:
@@ -502,6 +641,16 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-riscv64@0.25.2:
+    resolution: {integrity: sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-riscv64@0.27.7:
@@ -510,6 +659,16 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-s390x@0.25.2:
+    resolution: {integrity: sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-s390x@0.27.7:
@@ -518,6 +677,16 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/linux-x64@0.25.2:
+    resolution: {integrity: sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/linux-x64@0.27.7:
@@ -526,6 +695,16 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/netbsd-arm64@0.25.2:
+    resolution: {integrity: sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-arm64@0.27.7:
@@ -534,6 +713,16 @@ packages:
     cpu: [arm64]
     os: [netbsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/netbsd-x64@0.25.2:
+    resolution: {integrity: sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/netbsd-x64@0.27.7:
@@ -542,6 +731,16 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/openbsd-arm64@0.25.2:
+    resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-arm64@0.27.7:
@@ -550,6 +749,16 @@ packages:
     cpu: [arm64]
     os: [openbsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/openbsd-x64@0.25.2:
+    resolution: {integrity: sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/openbsd-x64@0.27.7:
@@ -558,6 +767,7 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@esbuild/openharmony-arm64@0.27.7:
@@ -569,12 +779,31 @@ packages:
     dev: false
     optional: true
 
+  /@esbuild/sunos-x64@0.25.2:
+    resolution: {integrity: sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@esbuild/sunos-x64@0.27.7:
     resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-arm64@0.25.2:
+    resolution: {integrity: sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-arm64@0.27.7:
@@ -583,6 +812,16 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-ia32@0.25.2:
+    resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-ia32@0.27.7:
@@ -591,6 +830,16 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@esbuild/win32-x64@0.25.2:
+    resolution: {integrity: sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@esbuild/win32-x64@0.27.7:
@@ -599,6 +848,7 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@eslint-community/eslint-utils@4.7.0(eslint@8.57.1):
@@ -743,7 +993,7 @@ packages:
       hastscript: 9.0.0
       postcss: 8.5.10
       postcss-nested: 6.0.1(postcss@8.5.10)
-      unist-util-visit: 5.1.0
+      unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.2
     dev: false
 
@@ -757,7 +1007,7 @@ packages:
     resolution: {integrity: sha512-DL605bLrUOgqTdZ0Ot5MlTaWzppRkzzqzeGEu7ODnHF39IkEBbFdsC7pbl3LbUQ1DFtnfx6rD54k/cdofbW6KQ==}
     dependencies:
       '@expressive-code/core': 0.41.7
-      shiki: 3.23.0
+      shiki: 3.21.0
     dev: false
 
   /@expressive-code/plugin-text-markers@0.41.7:
@@ -1037,7 +1287,7 @@ packages:
     cpu: [wasm32]
     requiresBuild: true
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.7.1
     dev: false
     optional: true
 
@@ -1082,7 +1332,7 @@ packages:
   /@mdx-js/mdx@3.1.1:
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.0
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.7
@@ -1251,16 +1501,33 @@ packages:
       rollup:
         optional: true
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       estree-walker: 2.0.2
       picomatch: 4.0.4
     dev: false
+
+  /@rollup/rollup-android-arm-eabi@4.40.2:
+    resolution: {integrity: sha512-JkdNEq+DFxZfUwxvB58tHMHBHVgX23ew41g1OQinthJ+ryhdRk67O31S7sYw8u2lTjHUPFxwar07BBt1KHp/hg==}
+    cpu: [arm]
+    os: [android]
+    requiresBuild: true
+    dev: true
+    optional: true
 
   /@rollup/rollup-android-arm-eabi@4.60.2:
     resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
     cpu: [arm]
     os: [android]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-android-arm64@4.40.2:
+    resolution: {integrity: sha512-13unNoZ8NzUmnndhPTkWPWbX3vtHodYmy+I9kuLxN+F+l+x3LdVF7UCu8TWVMt1POHLh6oDHhnOA04n8oJZhBw==}
+    cpu: [arm64]
+    os: [android]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-android-arm64@4.60.2:
@@ -1268,6 +1535,15 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-darwin-arm64@4.40.2:
+    resolution: {integrity: sha512-Gzf1Hn2Aoe8VZzevHostPX23U7N5+4D36WJNHK88NZHCJr7aVMG4fadqkIf72eqVPGjGc0HJHNuUaUcxiR+N/w==}
+    cpu: [arm64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.60.2:
@@ -1275,6 +1551,15 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-darwin-x64@4.40.2:
+    resolution: {integrity: sha512-47N4hxa01a4x6XnJoskMKTS8XZ0CZMd8YTbINbi+w03A2w4j1RTlnGHOz/P0+Bg1LaVL6ufZyNprSg+fW5nYQQ==}
+    cpu: [x64]
+    os: [darwin]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-darwin-x64@4.60.2:
@@ -1282,6 +1567,15 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-freebsd-arm64@4.40.2:
+    resolution: {integrity: sha512-8t6aL4MD+rXSHHZUR1z19+9OFJ2rl1wGKvckN47XFRVO+QL/dUSpKA2SLRo4vMg7ELA8pzGpC+W9OEd1Z/ZqoQ==}
+    cpu: [arm64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-arm64@4.60.2:
@@ -1289,6 +1583,15 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-freebsd-x64@4.40.2:
+    resolution: {integrity: sha512-C+AyHBzfpsOEYRFjztcYUFsH4S7UsE9cDtHCtma5BK8+ydOZYgMmWg1d/4KBytQspJCld8ZIujFMAdKG1xyr4Q==}
+    cpu: [x64]
+    os: [freebsd]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-freebsd-x64@4.60.2:
@@ -1296,6 +1599,15 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-arm-gnueabihf@4.40.2:
+    resolution: {integrity: sha512-de6TFZYIvJwRNjmW3+gaXiZ2DaWL5D5yGmSYzkdzjBDS3W+B9JQ48oZEsmMvemqjtAFzE16DIBLqd6IQQRuG9Q==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.60.2:
@@ -1303,6 +1615,15 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-arm-musleabihf@4.40.2:
+    resolution: {integrity: sha512-urjaEZubdIkacKc930hUDOfQPysezKla/O9qV+O89enqsqUmQm8Xj8O/vh0gHg4LYfv7Y7UsE3QjzLQzDYN1qg==}
+    cpu: [arm]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.60.2:
@@ -1310,6 +1631,15 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-arm64-gnu@4.40.2:
+    resolution: {integrity: sha512-KlE8IC0HFOC33taNt1zR8qNlBYHj31qGT1UqWqtvR/+NuCVhfufAq9fxO8BMFC22Wu0rxOwGVWxtCMvZVLmhQg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.60.2:
@@ -1317,6 +1647,15 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-arm64-musl@4.40.2:
+    resolution: {integrity: sha512-j8CgxvfM0kbnhu4XgjnCWJQyyBOeBI1Zq91Z850aUddUmPeQvuAy6OiMdPS46gNFgy8gN1xkYyLgwLYZG3rBOg==}
+    cpu: [arm64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.60.2:
@@ -1324,6 +1663,7 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-loong64-gnu@4.60.2:
@@ -1331,6 +1671,7 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-loong64-musl@4.60.2:
@@ -1341,11 +1682,28 @@ packages:
     dev: false
     optional: true
 
+  /@rollup/rollup-linux-loongarch64-gnu@4.40.2:
+    resolution: {integrity: sha512-Ybc/1qUampKuRF4tQXc7G7QY9YRyeVSykfK36Y5Qc5dmrIxwFhrOzqaVTNoZygqZ1ZieSWTibfFhQ5qK8jpWxw==}
+    cpu: [loong64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
+  /@rollup/rollup-linux-powerpc64le-gnu@4.40.2:
+    resolution: {integrity: sha512-3FCIrnrt03CCsZqSYAOW/k9n625pjpuMzVfeI+ZBUSDT3MVIFDSPfSUgIl9FqUftxcUXInvFah79hE1c9abD+Q==}
+    cpu: [ppc64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-ppc64-gnu@4.60.2:
     resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-linux-ppc64-musl@4.60.2:
@@ -1356,11 +1714,28 @@ packages:
     dev: false
     optional: true
 
+  /@rollup/rollup-linux-riscv64-gnu@4.40.2:
+    resolution: {integrity: sha512-QNU7BFHEvHMp2ESSY3SozIkBPaPBDTsfVNGx3Xhv+TdvWXFGOSH2NJvhD1zKAT6AyuuErJgbdvaJhYVhVqrWTg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-linux-riscv64-gnu@4.60.2:
     resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-riscv64-musl@4.40.2:
+    resolution: {integrity: sha512-5W6vNYkhgfh7URiXTO1E9a0cy4fSgfE4+Hl5agb/U1sa0kjOLMLC1wObxwKxecE17j0URxuTrYZZME4/VH57Hg==}
+    cpu: [riscv64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-riscv64-musl@4.60.2:
@@ -1368,6 +1743,15 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-s390x-gnu@4.40.2:
+    resolution: {integrity: sha512-B7LKIz+0+p348JoAL4X/YxGx9zOx3sR+o6Hj15Y3aaApNfAshK8+mWZEf759DXfRLeL2vg5LYJBB7DdcleYCoQ==}
+    cpu: [s390x]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-s390x-gnu@4.60.2:
@@ -1375,6 +1759,15 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-x64-gnu@4.40.2:
+    resolution: {integrity: sha512-lG7Xa+BmBNwpjmVUbmyKxdQJ3Q6whHjMjzQplOs5Z+Gj7mxPtWakGHqzMqNER68G67kmCX9qX57aRsW5V0VOng==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.60.2:
@@ -1382,6 +1775,15 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-linux-x64-musl@4.40.2:
+    resolution: {integrity: sha512-tD46wKHd+KJvsmije4bUskNuvWKFcTOIM9tZ/RrmIvcXnbi0YK/cKS9FzFtAm7Oxi2EhV5N2OpfFB348vSQRXA==}
+    cpu: [x64]
+    os: [linux]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-linux-x64-musl@4.60.2:
@@ -1389,6 +1791,7 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-openbsd-x64@4.60.2:
@@ -1407,11 +1810,28 @@ packages:
     dev: false
     optional: true
 
+  /@rollup/rollup-win32-arm64-msvc@4.40.2:
+    resolution: {integrity: sha512-Bjv/HG8RRWLNkXwQQemdsWw4Mg+IJ29LK+bJPW2SCzPKOUaMmPEppQlu/Fqk1d7+DX3V7JbFdbkh/NMmurT6Pg==}
+    cpu: [arm64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
+    optional: true
+
   /@rollup/rollup-win32-arm64-msvc@4.60.2:
     resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-win32-ia32-msvc@4.40.2:
+    resolution: {integrity: sha512-dt1llVSGEsGKvzeIO76HToiYPNPYPkmjhMHhP00T9S4rDern8P2ZWvWAQUEJ+R1UdMWJ/42i/QqJ2WV765GZcA==}
+    cpu: [ia32]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-ia32-msvc@4.60.2:
@@ -1419,6 +1839,7 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
+    dev: false
     optional: true
 
   /@rollup/rollup-win32-x64-gnu@4.60.2:
@@ -1426,6 +1847,15 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
+    dev: false
+    optional: true
+
+  /@rollup/rollup-win32-x64-msvc@4.40.2:
+    resolution: {integrity: sha512-bwspbWB04XJpeElvsp+DCylKfF4trJDa2Y9Go8O6A7YLX2LIKGcNK/CYImJN6ZP4DcuOHB4Utl3iCbnR62DudA==}
+    cpu: [x64]
+    os: [win32]
+    requiresBuild: true
+    dev: true
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.60.2:
@@ -1436,10 +1866,10 @@ packages:
     dev: false
     optional: true
 
-  /@shikijs/core@3.23.0:
-    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
+  /@shikijs/core@3.21.0:
+    resolution: {integrity: sha512-AXSQu/2n1UIQekY8euBJlvFYZIw0PHY63jUzGbrOma4wPxzznJXTXkri+QcHeBNaFxiiOljKxxJkVSoB3PjbyA==}
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
@@ -1456,12 +1886,12 @@ packages:
       hast-util-to-html: 9.0.5
     dev: false
 
-  /@shikijs/engine-javascript@3.23.0:
-    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
+  /@shikijs/engine-javascript@3.21.0:
+    resolution: {integrity: sha512-ATwv86xlbmfD9n9gKRiwuPpWgPENAWCLwYCGz9ugTJlsO2kOzhOkvoyV/UD+tJ0uT7YRyD530x6ugNSffmvIiQ==}
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
+      oniguruma-to-es: 4.3.4
     dev: false
 
   /@shikijs/engine-javascript@4.0.2:
@@ -1470,13 +1900,13 @@ packages:
     dependencies:
       '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.6
+      oniguruma-to-es: 4.3.4
     dev: false
 
-  /@shikijs/engine-oniguruma@3.23.0:
-    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
+  /@shikijs/engine-oniguruma@3.21.0:
+    resolution: {integrity: sha512-OYknTCct6qiwpQDqDdf3iedRdzj6hFlOPv5hMvI+hkWfCKs5mlJ4TXziBG9nyabLwGulrUjHiCq3xCspSzErYQ==}
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
     dev: false
 
@@ -1488,10 +1918,10 @@ packages:
       '@shikijs/vscode-textmate': 10.0.2
     dev: false
 
-  /@shikijs/langs@3.23.0:
-    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
+  /@shikijs/langs@3.21.0:
+    resolution: {integrity: sha512-g6mn5m+Y6GBJ4wxmBYqalK9Sp0CFkUqfNzUy2pJglUginz6ZpWbaWjDB4fbQ/8SHzFjYbtU6Ddlp1pc+PPNDVA==}
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 3.21.0
     dev: false
 
   /@shikijs/langs@4.0.2:
@@ -1510,10 +1940,10 @@ packages:
       '@types/hast': 3.0.4
     dev: false
 
-  /@shikijs/themes@3.23.0:
-    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
+  /@shikijs/themes@3.21.0:
+    resolution: {integrity: sha512-BAE4cr9EDiZyYzwIHEk7JTBJ9CzlPuM4PchfcA5ao1dWXb25nv6hYsoDiBq2aZK9E3dlt3WB78uI96UESD+8Mw==}
     dependencies:
-      '@shikijs/types': 3.23.0
+      '@shikijs/types': 3.21.0
     dev: false
 
   /@shikijs/themes@4.0.2:
@@ -1523,8 +1953,8 @@ packages:
       '@shikijs/types': 4.0.2
     dev: false
 
-  /@shikijs/types@3.23.0:
-    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
+  /@shikijs/types@3.21.0:
+    resolution: {integrity: sha512-zGrWOxZ0/+0ovPY7PvBU2gIS9tmhSUUt30jAcNV0Bq0gb2S98gwfjIs1vxlmH5zM7/4YxLamT6ChlqqAJmPPjA==}
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -1545,7 +1975,7 @@ packages:
   /@types/acorn@4.0.6:
     resolution: {integrity: sha512-veQTnWP+1D/xbxVrPC3zHnCZRjSrKfhbMUlEA43iMZLu7EsnTtkJklIuwrCPbOi8YkvDQAiW05VQQFvvz9oieQ==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
     dev: false
 
   /@types/d3-array@3.2.1:
@@ -1736,12 +2166,11 @@ packages:
   /@types/estree-jsx@1.0.0:
     resolution: {integrity: sha512-3qvGd0z8F2ENTGr/GG1yViqfiKmRfrXVx5sJyHGFu3z7m5g5utCQtGp/g29JnjflhtQJBv1WDQukHiT58xPcYQ==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
     dev: false
 
   /@types/estree@1.0.7:
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
-    dev: true
 
   /@types/estree@1.0.8:
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -2203,7 +2632,7 @@ packages:
     engines: {node: '>= 8'}
     dependencies:
       normalize-path: 3.0.0
-      picomatch: 2.3.2
+      picomatch: 2.3.1
     dev: false
 
   /arg@5.0.2:
@@ -2252,23 +2681,23 @@ packages:
       - supports-color
     dev: true
 
-  /astro-expressive-code@0.41.7(astro@6.1.8):
+  /astro-expressive-code@0.41.7(astro@6.1.9):
     resolution: {integrity: sha512-hUpogGc6DdAd+I7pPXsctyYPRBJDK7Q7d06s4cyP0Vz3OcbziP3FNzN0jZci1BpCvLn9675DvS7B9ctKKX64JQ==}
     peerDependencies:
       astro: ^4.0.0-beta || ^5.0.0-beta || ^3.3.0 || ^6.0.0-beta
     dependencies:
-      astro: 6.1.8(typescript@5.9.3)
+      astro: 6.1.9(typescript@5.9.3)
       rehype-expressive-code: 0.41.7
     dev: false
 
-  /astro@6.1.8(typescript@5.9.3):
-    resolution: {integrity: sha512-6fT9M12U3fpi13DiPavNKDIoBflASTSxmKTEe+zXhWtlebQuOqfOnIrMWyRmlXp+mgDsojmw+fVFG9LUTzKSog==}
+  /astro@6.1.9(typescript@5.9.3):
+    resolution: {integrity: sha512-NsAHzMzpznB281g2aM5qnBt2QjfH6ttKiZ3hSZw52If8JJ+62kbnBKbyKhR2glQcJLl7Jfe4GSl0DihFZ36rRQ==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
     dependencies:
       '@astrojs/compiler': 3.0.1
-      '@astrojs/internal-helpers': 0.8.0
-      '@astrojs/markdown-remark': 7.1.0
+      '@astrojs/internal-helpers': 0.9.0
+      '@astrojs/markdown-remark': 7.1.1
       '@astrojs/telemetry': 3.3.1
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.2.0
@@ -2281,9 +2710,9 @@ packages:
       common-ancestor-path: 2.0.0
       cookie: 1.1.1
       devalue: 5.7.1
-      diff: 8.0.4
+      diff: 8.0.3
       dset: 3.1.4
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.1.0
       esbuild: 0.27.7
       flattie: 1.1.1
       fontace: 0.4.1
@@ -2297,18 +2726,18 @@ packages:
       neotraverse: 0.6.18
       obug: 2.1.1
       p-limit: 7.3.0
-      p-queue: 9.1.2
+      p-queue: 9.2.0
       package-manager-detector: 1.6.0
       piccolore: 0.1.3
       picomatch: 4.0.4
       rehype: 13.0.2
       semver: 7.7.4
       shiki: 4.0.2
-      smol-toml: 1.6.1
+      smol-toml: 1.6.0
       svgo: 4.0.1
       tinyclip: 0.1.12
       tinyexec: 1.1.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       tsconfck: 3.1.6(typescript@5.9.3)
       ultrahtml: 1.6.0
       unifont: 0.7.4
@@ -2616,11 +3045,11 @@ packages:
       source-map-js: 1.2.1
     dev: false
 
-  /css-tree@3.2.1:
-    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+  /css-tree@3.1.0:
+    resolution: {integrity: sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
     dependencies:
-      mdn-data: 2.27.1
+      mdn-data: 2.12.2
       source-map-js: 1.2.1
     dev: false
 
@@ -3055,8 +3484,8 @@ packages:
       dequal: 2.0.3
     dev: false
 
-  /diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+  /diff@8.0.3:
+    resolution: {integrity: sha512-qejHi7bcSD4hQAZE0tNAawRK1ZtafHDmMTMkrrIGgSLl7hTnQHmKCeB45xAcbfTqK2zowkM3j3bHt/4b/ARbYQ==}
     engines: {node: '>=0.3.1'}
     dev: false
 
@@ -3142,8 +3571,8 @@ packages:
     engines: {node: '>=18'}
     dev: false
 
-  /es-module-lexer@2.0.0:
-    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+  /es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
     dev: false
 
   /esast-util-from-estree@2.0.0:
@@ -3164,13 +3593,45 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
+  /esbuild@0.25.2:
+    resolution: {integrity: sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+    requiresBuild: true
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.2
+      '@esbuild/android-arm': 0.25.2
+      '@esbuild/android-arm64': 0.25.2
+      '@esbuild/android-x64': 0.25.2
+      '@esbuild/darwin-arm64': 0.25.2
+      '@esbuild/darwin-x64': 0.25.2
+      '@esbuild/freebsd-arm64': 0.25.2
+      '@esbuild/freebsd-x64': 0.25.2
+      '@esbuild/linux-arm': 0.25.2
+      '@esbuild/linux-arm64': 0.25.2
+      '@esbuild/linux-ia32': 0.25.2
+      '@esbuild/linux-loong64': 0.25.2
+      '@esbuild/linux-mips64el': 0.25.2
+      '@esbuild/linux-ppc64': 0.25.2
+      '@esbuild/linux-riscv64': 0.25.2
+      '@esbuild/linux-s390x': 0.25.2
+      '@esbuild/linux-x64': 0.25.2
+      '@esbuild/netbsd-arm64': 0.25.2
+      '@esbuild/netbsd-x64': 0.25.2
+      '@esbuild/openbsd-arm64': 0.25.2
+      '@esbuild/openbsd-x64': 0.25.2
+      '@esbuild/sunos-x64': 0.25.2
+      '@esbuild/win32-arm64': 0.25.2
+      '@esbuild/win32-ia32': 0.25.2
+      '@esbuild/win32-x64': 0.25.2
+    dev: true
+
   /esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-<<<<<<< HEAD
       '@esbuild/aix-ppc64': 0.27.7
       '@esbuild/android-arm': 0.27.7
       '@esbuild/android-arm64': 0.27.7
@@ -3198,33 +3659,6 @@ packages:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
     dev: false
-=======
-      '@esbuild/aix-ppc64': 0.25.2
-      '@esbuild/android-arm': 0.25.2
-      '@esbuild/android-arm64': 0.25.2
-      '@esbuild/android-x64': 0.25.2
-      '@esbuild/darwin-arm64': 0.25.2
-      '@esbuild/darwin-x64': 0.25.2
-      '@esbuild/freebsd-arm64': 0.25.2
-      '@esbuild/freebsd-x64': 0.25.2
-      '@esbuild/linux-arm': 0.25.2
-      '@esbuild/linux-arm64': 0.25.2
-      '@esbuild/linux-ia32': 0.25.2
-      '@esbuild/linux-loong64': 0.25.2
-      '@esbuild/linux-mips64el': 0.25.2
-      '@esbuild/linux-ppc64': 0.25.2
-      '@esbuild/linux-riscv64': 0.25.2
-      '@esbuild/linux-s390x': 0.25.2
-      '@esbuild/linux-x64': 0.25.2
-      '@esbuild/netbsd-arm64': 0.25.2
-      '@esbuild/netbsd-x64': 0.25.2
-      '@esbuild/openbsd-arm64': 0.25.2
-      '@esbuild/openbsd-x64': 0.25.2
-      '@esbuild/sunos-x64': 0.25.2
-      '@esbuild/win32-arm64': 0.25.2
-      '@esbuild/win32-ia32': 0.25.2
-      '@esbuild/win32-x64': 0.25.2
->>>>>>> d72e9e9 (feat(docs): add feedback widget)
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3458,7 +3892,7 @@ packages:
   /estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
     dev: false
 
   /estree-util-build-jsx@3.0.1:
@@ -3477,7 +3911,7 @@ packages:
   /estree-util-scope@1.0.0:
     resolution: {integrity: sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       devlop: 1.1.0
     dev: false
 
@@ -3503,7 +3937,7 @@ packages:
   /estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
     dev: false
 
   /esutils@2.0.3:
@@ -3586,7 +4020,6 @@ packages:
         optional: true
     dependencies:
       picomatch: 4.0.3
-    dev: true
 
   /fdir@6.5.0(picomatch@4.0.4):
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -3658,11 +4091,11 @@ packages:
   /fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
     dependencies:
-      fontkitten: 1.0.3
+      fontkitten: 1.0.2
     dev: false
 
-  /fontkitten@1.0.3:
-    resolution: {integrity: sha512-Wp1zXWPVUPBmfoa3Cqc9ctaKuzKAV6uLstRqlR56kSjplf5uAce+qeyYym7F+PHbGTk+tCEdkCW6RD7DX/gBZw==}
+  /fontkitten@1.0.2:
+    resolution: {integrity: sha512-piJxbLnkD9Xcyi7dWJRnqszEURixe7CrF/efBfbffe2DPyabmuIuqraruY8cXTs19QoM8VJzx47BDRVNXETM7Q==}
     engines: {node: '>=20'}
     dependencies:
       tiny-inflate: 1.0.3
@@ -3897,14 +4330,14 @@ packages:
       nth-check: 2.1.1
       property-information: 6.5.0
       space-separated-tokens: 2.0.2
-      unist-util-visit: 5.1.0
+      unist-util-visit: 5.0.0
       zwitch: 2.0.4
     dev: false
 
   /hast-util-to-estree@3.1.0:
     resolution: {integrity: sha512-lfX5g6hqVh9kjS/B9E2gSkvHH4SZNiQFiqWS0x9fENzEl+8W12RqdRxX6d/Cwxi30tPQs3bIO+aolQJNp1bIyw==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.0
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -3943,7 +4376,7 @@ packages:
   /hast-util-to-jsx-runtime@2.3.0:
     resolution: {integrity: sha512-H/y0+IWPdsLLS738P8tDnrQ8Z+dj12zQQ6WC11TIM21C8WFVoIxcqWXf2H3hiTVZjF1AWqoimGwrTWecWrnmRQ==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       '@types/hast': 3.0.4
       '@types/unist': 3.0.3
       comma-separated-tokens: 2.0.3
@@ -4388,7 +4821,7 @@ packages:
     dependencies:
       '@types/mdast': 4.0.4
       escape-string-regexp: 5.0.0
-      unist-util-is: 6.0.1
+      unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.2
     dev: false
 
@@ -4568,7 +5001,7 @@ packages:
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
       unist-util-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     dev: false
 
@@ -4610,8 +5043,8 @@ packages:
     resolution: {integrity: sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g==}
     dev: false
 
-  /mdn-data@2.27.1:
-    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+  /mdn-data@2.12.2:
+    resolution: {integrity: sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==}
     dev: false
 
   /merge2@1.4.1:
@@ -4794,7 +5227,7 @@ packages:
   /micromark-extension-mdx-expression@3.0.0:
     resolution: {integrity: sha512-sI0nwhUDz97xyzqJAbHQhp5TfaxEvZZZ2JDqUo+7NvyIYG6BZ5CPPqj2ogUoPJlmXHBnyZUzISg9+oUmU6tUjQ==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.1
       micromark-factory-space: 2.0.1
@@ -4808,7 +5241,7 @@ packages:
     resolution: {integrity: sha512-uvhhss8OGuzR4/N17L1JwvmJIpPhAd8oByMawEKx6NVdBCbesjH4t+vjEp3ZXft9DwvlKSD07fCeI44/N0Vf2w==}
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.1
@@ -4828,7 +5261,7 @@ packages:
   /micromark-extension-mdxjs-esm@3.0.0:
     resolution: {integrity: sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
       micromark-util-character: 2.1.1
@@ -4872,7 +5305,7 @@ packages:
   /micromark-factory-mdx-expression@2.0.1:
     resolution: {integrity: sha512-F0ccWIUHRLRrYp5TC9ZYXmZo+p2AM13ggbsW4T0b5CRKP8KHVRB8t4pwtBgTxtjRmwrK0Irwm7vs2JOZabHZfg==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-util-character: 2.1.1
       micromark-util-events-to-acorn: 2.0.2
@@ -4958,7 +5391,7 @@ packages:
     resolution: {integrity: sha512-Fk+xmBrOv9QZnEDguL9OI9/NQQp6Hz4FuQ4YmCb/5V7+9eAh1s6AYSvL20kHkD67YIg7EpE54TiSlcsf3vyZgA==}
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -5074,10 +5507,6 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
-<<<<<<< HEAD
-    dev: false
-=======
->>>>>>> d72e9e9 (feat(docs): add feedback widget)
 
   /nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
@@ -5149,15 +5578,15 @@ packages:
       wrappy: 1.0.2
     dev: true
 
-  /oniguruma-parser@0.12.2:
-    resolution: {integrity: sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==}
+  /oniguruma-parser@0.12.1:
+    resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
     dev: false
 
-  /oniguruma-to-es@4.3.6:
-    resolution: {integrity: sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==}
+  /oniguruma-to-es@4.3.4:
+    resolution: {integrity: sha512-3VhUGN3w2eYxnTzHn+ikMI+fp/96KoRSVK9/kMTcFqj1NRDh2IhQCKvYxDnWePKRXY/AqH+Fuiyb7VHSzBjHfA==}
     dependencies:
-      oniguruma-parser: 0.12.2
-      regex: 6.1.0
+      oniguruma-parser: 0.12.1
+      regex: 6.0.1
       regex-recursion: 6.0.2
     dev: false
 
@@ -5198,8 +5627,8 @@ packages:
       p-limit: 3.1.0
     dev: true
 
-  /p-queue@9.1.2:
-    resolution: {integrity: sha512-ktsDOALzTYTWWF1PbkNVg2rOt+HaOaMWJMUnt7T3qf5tvZ1L8dBW3tObzprBcXNMKkwj+yFSLqHso0x+UFcJXw==}
+  /p-queue@9.2.0:
+    resolution: {integrity: sha512-dWgLE8AH0HjQ9fe74pUkKkvzzYT18Inp4zra3lKHnnwqGvcfcUBrvF2EAVX+envufDNBOzpPq/IBUONDbI7+3g==}
     engines: {node: '>=20'}
     dependencies:
       eventemitter3: 5.0.4
@@ -5309,17 +5738,10 @@ packages:
   /picomatch@2.3.1:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
-    dev: true
-
-  /picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-    dev: false
 
   /picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
-    dev: true
 
   /picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -5386,10 +5808,6 @@ packages:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
-<<<<<<< HEAD
-    dev: false
-=======
->>>>>>> d72e9e9 (feat(docs): add feedback widget)
 
   /postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -5463,7 +5881,7 @@ packages:
   /recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
     dev: false
@@ -5483,7 +5901,7 @@ packages:
   /recma-parse@1.0.0:
     resolution: {integrity: sha512-OYLsIGBB5Y5wjnSnQW6t3Xg7q3fQ7FWbw/vcXtORTnyaSFscOtABg+7Pnz6YZ6c27fG1/aN8CjfwoUEUIdwqWQ==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
@@ -5492,7 +5910,7 @@ packages:
   /recma-stringify@1.0.0:
     resolution: {integrity: sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       estree-util-to-js: 2.0.0
       unified: 11.0.5
       vfile: 6.0.3
@@ -5512,8 +5930,8 @@ packages:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
     dev: false
 
-  /regex@6.1.0:
-    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+  /regex@6.0.1:
+    resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
     dependencies:
       regex-utilities: 2.3.0
     dev: false
@@ -5556,7 +5974,7 @@ packages:
       hast-util-embedded: 3.0.0
       hast-util-is-element: 3.0.0
       hast-util-whitespace: 3.0.0
-      unist-util-is: 6.0.1
+      unist-util-is: 6.0.0
     dev: false
 
   /rehype-parse@9.0.0:
@@ -5578,7 +5996,7 @@ packages:
   /rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.7
       '@types/hast': 3.0.4
       hast-util-to-estree: 3.1.0
     transitivePeerDependencies:
@@ -5745,6 +6163,36 @@ packages:
     resolution: {integrity: sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==}
     dev: false
 
+  /rollup@4.40.2:
+    resolution: {integrity: sha512-tfUOg6DTP4rhQ3VjOO6B4wyrJnGOX85requAXvqYTHsOgb2TFJdZ3aWpT8W2kPoypSGP7dZUyzxJ9ee4buM5Fg==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+    dependencies:
+      '@types/estree': 1.0.7
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.40.2
+      '@rollup/rollup-android-arm64': 4.40.2
+      '@rollup/rollup-darwin-arm64': 4.40.2
+      '@rollup/rollup-darwin-x64': 4.40.2
+      '@rollup/rollup-freebsd-arm64': 4.40.2
+      '@rollup/rollup-freebsd-x64': 4.40.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.40.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.40.2
+      '@rollup/rollup-linux-arm64-gnu': 4.40.2
+      '@rollup/rollup-linux-arm64-musl': 4.40.2
+      '@rollup/rollup-linux-loongarch64-gnu': 4.40.2
+      '@rollup/rollup-linux-powerpc64le-gnu': 4.40.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.40.2
+      '@rollup/rollup-linux-riscv64-musl': 4.40.2
+      '@rollup/rollup-linux-s390x-gnu': 4.40.2
+      '@rollup/rollup-linux-x64-gnu': 4.40.2
+      '@rollup/rollup-linux-x64-musl': 4.40.2
+      '@rollup/rollup-win32-arm64-msvc': 4.40.2
+      '@rollup/rollup-win32-ia32-msvc': 4.40.2
+      '@rollup/rollup-win32-x64-msvc': 4.40.2
+      fsevents: 2.3.3
+    dev: true
+
   /rollup@4.60.2:
     resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -5778,6 +6226,7 @@ packages:
       '@rollup/rollup-win32-x64-gnu': 4.60.2
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
+    dev: false
 
   /roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -5811,6 +6260,10 @@ packages:
     dependencies:
       suf-log: 2.5.3
     dev: true
+
+  /sax@1.4.3:
+    resolution: {integrity: sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==}
+    dev: false
 
   /sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -5881,15 +6334,15 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /shiki@3.23.0:
-    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
+  /shiki@3.21.0:
+    resolution: {integrity: sha512-N65B/3bqL/TI2crrXr+4UivctrAGEjmsib5rPMMPpFp1xAx/w03v8WZ9RDDFYteXoEgY7qZ4HGgl5KBIu1153w==}
     dependencies:
-      '@shikijs/core': 3.23.0
-      '@shikijs/engine-javascript': 3.23.0
-      '@shikijs/engine-oniguruma': 3.23.0
-      '@shikijs/langs': 3.23.0
-      '@shikijs/themes': 3.23.0
-      '@shikijs/types': 3.23.0
+      '@shikijs/core': 3.21.0
+      '@shikijs/engine-javascript': 3.21.0
+      '@shikijs/engine-oniguruma': 3.21.0
+      '@shikijs/langs': 3.21.0
+      '@shikijs/themes': 3.21.0
+      '@shikijs/types': 3.21.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
     dev: false
@@ -5920,7 +6373,7 @@ packages:
       '@types/node': 24.12.2
       '@types/sax': 1.2.4
       arg: 5.0.2
-      sax: 1.6.0
+      sax: 1.4.3
     dev: false
 
   /slash@3.0.0:
@@ -5928,8 +6381,8 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+  /smol-toml@1.6.0:
+    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
     engines: {node: '>= 18'}
     dev: false
 
@@ -5946,32 +6399,32 @@ packages:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
     dev: false
 
-  /starlight-fullview-mode@0.2.6(@astrojs/starlight@0.38.3):
+  /starlight-fullview-mode@0.2.6(@astrojs/starlight@0.38.4):
     resolution: {integrity: sha512-gXVTOUVkObbfR+iS6Y1i/uR5JHGKow3CtRZnx0IbWW+TWLBaYZ0fsbGrjdH2ELMF2qvkHzco3uQD1xmrMaKy7g==}
     engines: {node: ^18.17.1 || ^20.3.0 || >=21.0.0}
     peerDependencies:
       '@astrojs/starlight': '>=0.32'
     dependencies:
-      '@astrojs/starlight': 0.38.3(astro@6.1.8)
+      '@astrojs/starlight': 0.38.4(astro@6.1.9)
       '@iconify-json/mdi': 1.2.3
     dev: false
 
-  /starlight-links-validator@0.23.0(@astrojs/starlight@0.38.3)(astro@6.1.8):
+  /starlight-links-validator@0.23.0(@astrojs/starlight@0.38.4)(astro@6.1.9):
     resolution: {integrity: sha512-dpKJdNv170+jyw8HDgPKGIW/MnXUxa3v8RqJrER47jx4fbxvLsITIw0/Y76xzTTrDv8LhQ7t/ExFutUDQqm3FQ==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
       '@astrojs/starlight': '>=0.38.0'
       astro: '>=6.0.0'
     dependencies:
-      '@astrojs/starlight': 0.38.3(astro@6.1.8)
+      '@astrojs/starlight': 0.38.4(astro@6.1.9)
       '@types/picomatch': 4.0.3
-      astro: 6.1.8(typescript@5.9.3)
+      astro: 6.1.9(typescript@5.9.3)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       is-absolute-url: 5.0.0
       mdast-util-mdx-jsx: 3.2.0
       mdast-util-to-hast: 13.2.1
-      picomatch: 4.0.4
+      picomatch: 4.0.3
       terminal-link: 5.0.0
       unist-util-visit: 5.1.0
       yaml: 2.8.3
@@ -5979,7 +6432,7 @@ packages:
       - supports-color
     dev: false
 
-  /starlight-openapi@0.24.0(@astrojs/markdown-remark@7.1.0)(@astrojs/starlight@0.38.3)(astro@6.1.8)(openapi-types@12.1.3):
+  /starlight-openapi@0.24.0(@astrojs/markdown-remark@7.1.1)(@astrojs/starlight@0.38.4)(astro@6.1.9)(openapi-types@12.1.3):
     resolution: {integrity: sha512-h0cKk6rysSoVewQ7ueSIzFaluyvSMJKttsLMuvX1dqMt0Q3H6rdlFE401gBRfS+76LP2LtRoK0IBzsbitcRu4w==}
     engines: {node: '>=22.12.0'}
     peerDependencies:
@@ -5987,10 +6440,10 @@ packages:
       '@astrojs/starlight': '>=0.38.0'
       astro: '>=6.0.0'
     dependencies:
-      '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/starlight': 0.38.3(astro@6.1.8)
+      '@astrojs/markdown-remark': 7.1.1
+      '@astrojs/starlight': 0.38.4(astro@6.1.9)
       '@readme/openapi-parser': 4.1.2(openapi-types@12.1.3)
-      astro: 6.1.8(typescript@5.9.3)
+      astro: 6.1.9(typescript@5.9.3)
       github-slugger: 2.0.0
       url-template: 3.1.1
     transitivePeerDependencies:
@@ -6069,7 +6522,7 @@ packages:
     dependencies:
       commander: 11.1.0
       css-select: 5.2.2
-      css-tree: 3.2.1
+      css-tree: 3.1.0
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
@@ -6120,15 +6573,6 @@ packages:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
-    dev: true
-
-  /tinyglobby@0.2.16:
-    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
-    dev: false
 
   /to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
@@ -6267,7 +6711,7 @@ packages:
   /unifont@0.7.4:
     resolution: {integrity: sha512-oHeis4/xl42HUIeHuNZRGEvxj5AaIKR+bHPNegRq5LV1gdc3jundpONbjglKpihmJf+dswygdMJn3eftGIMemg==}
     dependencies:
-      css-tree: 3.2.1
+      css-tree: 3.1.0
       ofetch: 1.5.1
       ohash: 2.0.11
     dev: false
@@ -6281,12 +6725,6 @@ packages:
 
   /unist-util-is@6.0.0:
     resolution: {integrity: sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw==}
-    dependencies:
-      '@types/unist': 3.0.3
-    dev: false
-
-  /unist-util-is@6.0.1:
-    resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
     dependencies:
       '@types/unist': 3.0.3
     dev: false
@@ -6340,7 +6778,7 @@ packages:
     resolution: {integrity: sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==}
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
+      unist-util-is: 6.0.0
     dev: false
 
   /unist-util-visit@5.0.0:
@@ -6355,7 +6793,7 @@ packages:
     resolution: {integrity: sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==}
     dependencies:
       '@types/unist': 3.0.3
-      unist-util-is: 6.0.1
+      unist-util-is: 6.0.0
       unist-util-visit-parents: 6.0.2
     dev: false
 
@@ -6470,6 +6908,56 @@ packages:
       vfile-message: 4.0.2
     dev: false
 
+  /vite@6.4.1:
+    resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+    dependencies:
+      esbuild: 0.25.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.10
+      rollup: 4.40.2
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+    dev: true
+
   /vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -6510,23 +6998,15 @@ packages:
       yaml:
         optional: true
     dependencies:
-<<<<<<< HEAD
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.60.2
-      tinyglobby: 0.2.16
-=======
-      esbuild: 0.25.2
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
-      postcss: 8.5.10
-      rollup: 4.40.2
       tinyglobby: 0.2.15
->>>>>>> d72e9e9 (feat(docs): add feedback widget)
     optionalDependencies:
       fsevents: 2.3.3
+    dev: false
 
   /vitefu@1.1.3(vite@7.3.2):
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,6 +102,9 @@ importers:
       typescript-eslint:
         specifier: ^8.54.0
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
+      vite:
+        specifier: ^6.4.1
+        version: 6.4.1
 
 packages:
 
@@ -395,7 +398,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm64@0.27.7:
@@ -404,7 +406,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-arm@0.27.7:
@@ -413,7 +414,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/android-x64@0.27.7:
@@ -422,7 +422,6 @@ packages:
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-arm64@0.27.7:
@@ -431,7 +430,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/darwin-x64@0.27.7:
@@ -440,7 +438,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-arm64@0.27.7:
@@ -449,7 +446,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/freebsd-x64@0.27.7:
@@ -458,7 +454,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm64@0.27.7:
@@ -467,7 +462,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-arm@0.27.7:
@@ -476,7 +470,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ia32@0.27.7:
@@ -485,7 +478,6 @@ packages:
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-loong64@0.27.7:
@@ -494,7 +486,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-mips64el@0.27.7:
@@ -503,7 +494,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-ppc64@0.27.7:
@@ -512,7 +502,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-riscv64@0.27.7:
@@ -521,7 +510,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-s390x@0.27.7:
@@ -530,7 +518,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/linux-x64@0.27.7:
@@ -539,7 +526,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-arm64@0.27.7:
@@ -548,7 +534,6 @@ packages:
     cpu: [arm64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/netbsd-x64@0.27.7:
@@ -557,7 +542,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-arm64@0.27.7:
@@ -566,7 +550,6 @@ packages:
     cpu: [arm64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openbsd-x64@0.27.7:
@@ -575,7 +558,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/openharmony-arm64@0.27.7:
@@ -593,7 +575,6 @@ packages:
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-arm64@0.27.7:
@@ -602,7 +583,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-ia32@0.27.7:
@@ -611,7 +591,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@esbuild/win32-x64@0.27.7:
@@ -620,7 +599,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@eslint-community/eslint-utils@4.7.0(eslint@8.57.1):
@@ -1283,7 +1261,6 @@ packages:
     cpu: [arm]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-android-arm64@4.60.2:
@@ -1291,7 +1268,6 @@ packages:
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-darwin-arm64@4.60.2:
@@ -1299,7 +1275,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-darwin-x64@4.60.2:
@@ -1307,7 +1282,6 @@ packages:
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-freebsd-arm64@4.60.2:
@@ -1315,7 +1289,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-freebsd-x64@4.60.2:
@@ -1323,7 +1296,6 @@ packages:
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm-gnueabihf@4.60.2:
@@ -1331,7 +1303,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm-musleabihf@4.60.2:
@@ -1339,7 +1310,6 @@ packages:
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm64-gnu@4.60.2:
@@ -1347,7 +1317,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-arm64-musl@4.60.2:
@@ -1355,7 +1324,6 @@ packages:
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-loong64-gnu@4.60.2:
@@ -1363,7 +1331,6 @@ packages:
     cpu: [loong64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-loong64-musl@4.60.2:
@@ -1379,7 +1346,6 @@ packages:
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-ppc64-musl@4.60.2:
@@ -1395,7 +1361,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-riscv64-musl@4.60.2:
@@ -1403,7 +1368,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-s390x-gnu@4.60.2:
@@ -1411,7 +1375,6 @@ packages:
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-x64-gnu@4.60.2:
@@ -1419,7 +1382,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-linux-x64-musl@4.60.2:
@@ -1427,7 +1389,6 @@ packages:
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-openbsd-x64@4.60.2:
@@ -1451,7 +1412,6 @@ packages:
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-win32-ia32-msvc@4.60.2:
@@ -1459,7 +1419,6 @@ packages:
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-win32-x64-gnu@4.60.2:
@@ -1467,7 +1426,6 @@ packages:
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   /@rollup/rollup-win32-x64-msvc@4.60.2:
@@ -3212,6 +3170,7 @@ packages:
     hasBin: true
     requiresBuild: true
     optionalDependencies:
+<<<<<<< HEAD
       '@esbuild/aix-ppc64': 0.27.7
       '@esbuild/android-arm': 0.27.7
       '@esbuild/android-arm64': 0.27.7
@@ -3239,6 +3198,33 @@ packages:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
     dev: false
+=======
+      '@esbuild/aix-ppc64': 0.25.2
+      '@esbuild/android-arm': 0.25.2
+      '@esbuild/android-arm64': 0.25.2
+      '@esbuild/android-x64': 0.25.2
+      '@esbuild/darwin-arm64': 0.25.2
+      '@esbuild/darwin-x64': 0.25.2
+      '@esbuild/freebsd-arm64': 0.25.2
+      '@esbuild/freebsd-x64': 0.25.2
+      '@esbuild/linux-arm': 0.25.2
+      '@esbuild/linux-arm64': 0.25.2
+      '@esbuild/linux-ia32': 0.25.2
+      '@esbuild/linux-loong64': 0.25.2
+      '@esbuild/linux-mips64el': 0.25.2
+      '@esbuild/linux-ppc64': 0.25.2
+      '@esbuild/linux-riscv64': 0.25.2
+      '@esbuild/linux-s390x': 0.25.2
+      '@esbuild/linux-x64': 0.25.2
+      '@esbuild/netbsd-arm64': 0.25.2
+      '@esbuild/netbsd-x64': 0.25.2
+      '@esbuild/openbsd-arm64': 0.25.2
+      '@esbuild/openbsd-x64': 0.25.2
+      '@esbuild/sunos-x64': 0.25.2
+      '@esbuild/win32-arm64': 0.25.2
+      '@esbuild/win32-ia32': 0.25.2
+      '@esbuild/win32-x64': 0.25.2
+>>>>>>> d72e9e9 (feat(docs): add feedback widget)
 
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
@@ -3691,7 +3677,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   /github-slugger@2.0.0:
@@ -5089,7 +5074,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+<<<<<<< HEAD
     dev: false
+=======
+>>>>>>> d72e9e9 (feat(docs): add feedback widget)
 
   /nanoid@3.3.8:
     resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
@@ -5398,7 +5386,10 @@ packages:
       nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
+<<<<<<< HEAD
     dev: false
+=======
+>>>>>>> d72e9e9 (feat(docs): add feedback widget)
 
   /postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
@@ -5787,7 +5778,6 @@ packages:
       '@rollup/rollup-win32-x64-gnu': 4.60.2
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
-    dev: false
 
   /roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
@@ -6520,15 +6510,23 @@ packages:
       yaml:
         optional: true
     dependencies:
+<<<<<<< HEAD
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.60.2
       tinyglobby: 0.2.16
+=======
+      esbuild: 0.25.2
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.10
+      rollup: 4.40.2
+      tinyglobby: 0.2.15
+>>>>>>> d72e9e9 (feat(docs): add feedback widget)
     optionalDependencies:
       fsevents: 2.3.3
-    dev: false
 
   /vitefu@1.1.3(vite@7.3.2):
     resolution: {integrity: sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==}


### PR DESCRIPTION
## Description of changes

- Add a docs feedback widget in the footer.
- Add a Netlify function that creates GitHub issues for feedback.
- Add Netlify local dev config and docs for setup/testing.
- Add a local Netlify dev script and env example.
- Ignore local `.netlify` files.

## Checklist

- [x] PR title is prefixed with `docs:`
- [x] PR title or description includes `fixes #`
- [x] Run `pnpm format` and `pnpm lint`
- [ ] Review Vale output if applicable
