### PR TITLE
docs: add a redirect from /docs

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -552,6 +552,7 @@ export default defineConfig({
     })
   ],
   redirects: {
+    '/docs': '/overview/getting-started',
     '/introduction/wallet-addresses': '/concepts/wallet-addresses',
     '/sdk/grant-create': '/sdk/grant-create-incoming'
   },


### PR DESCRIPTION
**Description of changes**

I often end up visiting /docs page (it's in my browser history for some reason), which is a 404. There's a chance some other users might end up visiting same.

Add a redirect so users see something more than 404.

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
