### PR TITLE
docs: add SDK page for get spent amounts on outgoing payment grant

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -323,6 +323,10 @@ export default defineConfig({
                 {
                   label: 'Get an outgoing payment',
                   link: '/sdk/outgoing-get/'
+                },
+                {
+                  label: 'Get spent amounts for current outgoing payment grant',
+                  link: '/sdk/outgoing-grant-spent-amounts/'
                 }
               ]
             },

--- a/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
+++ b/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
@@ -1,0 +1,82 @@
+---
+title: Get spent amounts for current outgoing payment grant
+---
+
+import { LinkOut } from '@interledger/docs-design-system'
+import { Tabs, TabItem, LinkButton, Badge } from '@astrojs/starlight/components'
+import Begin from '/src/content/docs/partials/_before-you-begin.mdx'
+import Ts from '/src/content/docs/partials/_ts-init-config.mdx'
+
+The [Get Spent Amounts for Current Outgoing Payment Grant API](/apis/resource-server/operations/get-outgoing-payment-grant) returns the amounts spent and received for a specific outgoing payment grant.
+
+Using the ID of the outgoing payment resource, a client can check how much of the grant's authorized limit has been consumed so far.
+
+The code snippets below let an authorized client retrieve the spent amounts for a given outgoing payment grant.
+
+## Before you begin
+
+<Begin />
+
+## Get the spent amounts for an outgoing payment grant
+
+<Badge text="Authenticated client required" variant="note" />
+
+<Tabs syncKey="langs">
+<TabItem label='TypeScript/NodeJS' icon='node'>
+<LinkButton href="https://github.com/interledger/open-payments-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
+
+<details>
+  <summary>Initial configuration</summary>
+  <Ts />
+</details>
+
+```ts wrap
+// Coming soon
+```
+
+</TabItem>
+<TabItem label="Rust" icon='seti:rust'>
+<LinkButton href="https://github.com/interledger/open-payments-rust/tree/main/src/snippets#readme" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
+
+```rust wrap
+// Coming soon
+```
+
+</TabItem>
+<TabItem label='PHP' icon='seti:php'>
+<LinkButton href="https://github.com/interledger/open-payments-php-snippets/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
+
+```php wrap
+// Coming soon
+```
+
+</TabItem>
+<TabItem label="Go" icon='seti:go'>
+<LinkButton href="https://github.com/interledger/open-payments-go/blob/main/README.md" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
+
+```go wrap
+// Coming soon
+```
+
+</TabItem>
+<TabItem label='Java' icon='seti:java'>
+<LinkButton href="https://github.com/interledger/open-payments-java?tab=readme-ov-file#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
+
+```java wrap
+// Coming soon
+```
+
+</TabItem>
+<TabItem label='.NET' icon='seti:c-sharp'>
+<LinkButton href="https://github.com/interledger/open-payments-dotnet/blob/main/README.md#prerequisites" target="_blank" icon="external" iconPlacement="start">Prerequisites</LinkButton>
+
+```csharp wrap
+// Coming soon
+```
+
+</TabItem>
+</Tabs>
+
+## References
+
+- [API specification](/apis/resource-server/operations/get-outgoing-payment-grant)

--- a/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
+++ b/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
@@ -7,11 +7,11 @@ import { Tabs, TabItem, LinkButton, Badge } from '@astrojs/starlight/components'
 import Begin from '/src/content/docs/partials/_before-you-begin.mdx'
 import Ts from '/src/content/docs/partials/_ts-init-config.mdx'
 
-The [Get Spent Amounts for Current Outgoing Payment Grant API](/apis/resource-server/operations/get-outgoing-payment-grant) returns the amounts spent and received for a specific outgoing payment grant.
+The [Get Spent Amounts for Current Outgoing Payment Grant API](/apis/resource-server/operations/get-outgoing-payment-grant) returns the debit and receive amounts spent against an outgoing payment grant.
 
-Using the ID of the outgoing payment resource, a client can check how much of the grant's authorized limit has been consumed so far.
+The grant is identified by the client's GNAP access token. For grants created with a recurring interval, the amounts returned reflect the current interval only.
 
-The code snippets below let an authorized client retrieve the spent amounts for a given outgoing payment grant.
+The code snippets below let an authorized client retrieve the spent amounts for the current outgoing payment grant.
 
 ## Before you begin
 


### PR DESCRIPTION
Fixes # DOC-37

Adds a new SDK page scaffolding the 'Get spent amounts for current outgoing payment grant' operation across all six SDK languages (TS/NodeJS, Rust, PHP, Go, Java, .NET). Code snippets are placeholders pending developer contributions. Page is wired into the Outgoing payments sidebar section.

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
