### PR TITLE
docs: update grant spent amount sdk overview

### DIFF
--- a/docs/src/content/docs/partials/code/guides/outgoing-grant-future-payments/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/outgoing-grant-future-payments/_request-a-grant-continuation.mdx
@@ -6,7 +6,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
 ```ts wrap
 const userOutgoingPaymentGrant = await client.grant.continue(
   {
-    accessToken: pendingUserOutgoingPaymentGrant.continue.acces_token.value,
+    accessToken: pendingUserOutgoingPaymentGrant.continue.access_token.value,
     url: pendingUserOutgoingPaymentGrant.continue.uri
   },
   {

--- a/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
+++ b/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
@@ -9,7 +9,7 @@ import Ts from '/src/content/docs/partials/_ts-init-config.mdx'
 
 The [Get Spent Amounts for Current Outgoing Payment Grant API](/apis/resource-server/operations/get-outgoing-payment-grant) returns the debit and receive amounts spent against the current outgoing payment grant.
 
-When an outgoing payment [grant continuation request](/apis/resource-server/operations/post-continue) is successful, the client receives an access token from the authorization server. The current grant is identified by this access token. 
+When an outgoing payment [grant continuation request](/apis/resource-server/operations/post-continue) is successful, the client receives an access token from the authorization server. The current grant is identified by this access token.
 
 The code snippets below let an authorized client retrieve the spent amounts for the current outgoing payment grant. For grants created with a recurring interval, the amounts returned reflect the current interval only.
 

--- a/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
+++ b/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
@@ -7,11 +7,11 @@ import { Tabs, TabItem, LinkButton, Badge } from '@astrojs/starlight/components'
 import Begin from '/src/content/docs/partials/_before-you-begin.mdx'
 import Ts from '/src/content/docs/partials/_ts-init-config.mdx'
 
-The [Get Spent Amounts for Current Outgoing Payment Grant API](/apis/resource-server/operations/get-outgoing-payment-grant) returns the debit and receive amounts spent against an outgoing payment grant.
+The [Get Spent Amounts for Current Outgoing Payment Grant API](/apis/resource-server/operations/get-outgoing-payment-grant) returns the debit and receive amounts spent against the current outgoing payment grant.
 
-The grant is identified by the client's GNAP access token. For grants created with a recurring interval, the amounts returned reflect the current interval only.
+When an outgoing payment [grant continuation request](/apis/resource-server/operations/post-continue) is successful, the client receives an access token from the authorization server. The current grant is identified by this access token. 
 
-The code snippets below let an authorized client retrieve the spent amounts for the current outgoing payment grant.
+The code snippets below let an authorized client retrieve the spent amounts for the current outgoing payment grant. For grants created with a recurring interval, the amounts returned reflect the current interval only.
 
 ## Before you begin
 


### PR DESCRIPTION
**Description of changes**

Updated the overview with a few additional details based on comments Sid had when adding the TS/Node code snippets to the Grant Spent Amount SDK page.

There's no related Linear issue/no fixes #.

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
