### PR TITLE
chore: update Node snippets & guides with new `isFinalizedGrantWithAccessToken` function

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ generated
 dist
 build
 landing
+snippets

--- a/docs/src/content/docs/partials/code/guides/accept-otp-online-purchase/_grant-request-incoming-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/accept-otp-online-purchase/_grant-request-incoming-payment.mdx
@@ -19,6 +19,10 @@ const retailerIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(retailerIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/accept-otp-online-purchase/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/accept-otp-online-purchase/_grant-request-outgoing-payment.mdx
@@ -35,6 +35,10 @@ const pendingCustomerOutgoingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isPendingGrant(pendingCustomerOutgoingPaymentGrant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/accept-otp-online-purchase/_grant-request-quote.mdx
+++ b/docs/src/content/docs/partials/code/guides/accept-otp-online-purchase/_grant-request-quote.mdx
@@ -19,6 +19,10 @@ const customerQuoteGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(customerQuoteGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_grant-request-incoming-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_grant-request-incoming-payment.mdx
@@ -19,6 +19,10 @@ const recipientIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(recipientIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
  </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_grant-request-outgoing-payment.mdx
@@ -36,6 +36,10 @@ const pendingSenderOutgoingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isPendingGrant(pendingSenderOutgoingPaymentGrant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
  </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_grant-request-quote.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_grant-request-quote.mdx
@@ -19,6 +19,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
         }
       }
     )
+    if (!isFinalizedGrantWithAccessToken(senderQuoteGrant)) {
+      throw new Error('Expected finalized grant')
+    }
     ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-debit/_request-a-grant-continuation.mdx
@@ -13,6 +13,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
         interact_ref: interactRef
       }
     )
+
+    if (!isFinalizedGrantWithAccessToken(senderOutgoingPaymentGrant)) {
+      throw new Error('Expected finalized grant')
+    }
     ```
 
  </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_grant-request-incoming-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_grant-request-incoming-payment.mdx
@@ -19,6 +19,10 @@ const recipientIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(recipientIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_grant-request-outgoing-payment.mdx
@@ -35,6 +35,10 @@ const pendingSenderOutgoingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isPendingGrant(pendingSenderOutgoingPaymentGrant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_grant-request-quote.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_grant-request-quote.mdx
@@ -19,6 +19,10 @@ const senderQuoteGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(senderQuoteGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/onetime-remittance-fixed-receive/_request-a-grant-continuation.mdx
@@ -13,6 +13,10 @@ const senderOutgoingPaymentGrant = await client.grant.continue(
     interact_ref: interactRef
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(senderOutgoingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/outgoing-grant-future-payments/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/outgoing-grant-future-payments/_grant-request-outgoing-payment.mdx
@@ -37,6 +37,10 @@ const grant = await client.grant.request(
     },
   },
 );
+
+if (!isPendingGrant(grant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
  </TabItem>

--- a/docs/src/content/docs/partials/code/guides/outgoing-grant-future-payments/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/outgoing-grant-future-payments/_request-a-grant-continuation.mdx
@@ -13,6 +13,10 @@ const userOutgoingPaymentGrant = await client.grant.continue(
     interact_ref: interactRef
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(userOutgoingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-debit/_grant-request-incoming-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-debit/_grant-request-incoming-payment.mdx
@@ -19,6 +19,10 @@ const recipientIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(recipientIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-debit/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-debit/_grant-request-outgoing-payment.mdx
@@ -36,6 +36,10 @@ const pendingSenderOutgoingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isPendingGrant(pendingSenderOutgoingPaymentGrant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
 </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-debit/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-debit/_request-a-grant-continuation.mdx
@@ -13,6 +13,10 @@ const senderOutgoingPaymentGrant = await client.grant.continue(
     interact_ref: interactRef
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(senderOutgoingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_grant-request-incoming-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_grant-request-incoming-payment.mdx
@@ -19,6 +19,10 @@ const recipientIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(recipientIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_grant-request-outgoing-payment.mdx
@@ -36,6 +36,10 @@ const pendingSenderOutgoingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isPendingGrant(pendingSenderOutgoingPaymentGrant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
 </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_grant-request-quote.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_grant-request-quote.mdx
@@ -19,6 +19,10 @@ const senderQuoteGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(senderQuoteGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-remittance-fixed-receive/_request-a-grant-continuation.mdx
@@ -13,6 +13,10 @@ const senderOutgoingPaymentGrant = await client.grant.continue(
     interact_ref: interactRef
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(senderOutgoingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_grant-request-incoming-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_grant-request-incoming-payment.mdx
@@ -19,6 +19,10 @@ const serviceProviderIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(serviceProviderIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
 </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_grant-request-outgoing-payment.mdx
@@ -36,6 +36,10 @@ const pendingCustomerOutgoingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isPendingGrant(pendingCustomerOutgoingPaymentGrant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
 </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_grant-request-quote.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_grant-request-quote.mdx
@@ -19,6 +19,10 @@ const customerQuoteGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(customerQuoteGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
 </TabItem>

--- a/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/recurring-subscription-incoming-amount/_request-a-grant-continuation.mdx
@@ -13,6 +13,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
         interact_ref: interactRef
       }
     )
+
+    if (!isFinalizedGrantWithAccessToken(customerOutgoingPaymentGrant)) {
+      throw new Error('Expected finalized grant')
+    }
     ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/split-payments/_grant-request-incoming-payments.mdx
+++ b/docs/src/content/docs/partials/code/guides/split-payments/_grant-request-incoming-payments.mdx
@@ -20,6 +20,11 @@ const merchantIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(merchantIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
+
 // Platform
 const platformIncomingPaymentGrant = await client.grant.request(
   {
@@ -36,6 +41,10 @@ const platformIncomingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isFinalizedGrantWithAccessToken(platformIncomingPaymentGrant)) {
+  throw new Error('Expected finalized grant')
+}
 ```
 
  </TabItem>

--- a/docs/src/content/docs/partials/code/guides/split-payments/_grant-request-outgoing-payment.mdx
+++ b/docs/src/content/docs/partials/code/guides/split-payments/_grant-request-outgoing-payment.mdx
@@ -37,6 +37,10 @@ const pendingCustomerOutgoingPaymentGrant = await client.grant.request(
     }
   }
 )
+
+if (!isPendingGrant(pendingCustomerOutgoingPaymentGrant)) {
+  throw new Error('Expected pending/interactive grant')
+}
 ```
 
  </TabItem>

--- a/docs/src/content/docs/partials/code/guides/split-payments/_grant-request-quote.mdx
+++ b/docs/src/content/docs/partials/code/guides/split-payments/_grant-request-quote.mdx
@@ -19,6 +19,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
         }
       }
     )
+
+    if (!isFinalizedGrantWithAccessToken(customerQuoteGrant)) {
+      throw new Error('Expected finalized grant')
+    }
     ```
 
   </TabItem>

--- a/docs/src/content/docs/partials/code/guides/split-payments/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/split-payments/_request-a-grant-continuation.mdx
@@ -13,6 +13,10 @@ import { Tabs, TabItem } from '@astrojs/starlight/components'
         interact_ref: interactRef
       }
     )
+
+    if (!isFinalizedGrantWithAccessToken(customerOutgoingPaymentGrant)) {
+      throw new Error('Expected finalized grant')
+    }
     ```
 
   </TabItem>

--- a/docs/src/content/docs/sdk/grant-continue.mdx
+++ b/docs/src/content/docs/sdk/grant-continue.mdx
@@ -45,7 +45,7 @@ import {
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/grant-continue.mdx
+++ b/docs/src/content/docs/sdk/grant-continue.mdx
@@ -38,7 +38,10 @@ The code snippets below let an authorized client send a grant continuation reque
 
 ```ts wrap
 // Import dependencies
-import { createAuthenticatedClient } from '@interledger/open-payments'
+import {
+  createAuthenticatedClient,
+  isFinalizedGrantWithAccessToken
+} from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
@@ -59,8 +62,8 @@ const grant = await client.grant.continue(
 )
 
 // Check grant state
-if (!isFinalizedGrant(grant)) {
-  throw new Error('Expected finalized grant. Received non-finalized grant.')
+if (!isFinalizedGrantWithAccessToken(grant)) {
+  throw new Error('Expected finalized grant')
 }
 
 // Output

--- a/docs/src/content/docs/sdk/grant-create-incoming.mdx
+++ b/docs/src/content/docs/sdk/grant-create-incoming.mdx
@@ -41,7 +41,7 @@ import {
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/grant-create-incoming.mdx
+++ b/docs/src/content/docs/sdk/grant-create-incoming.mdx
@@ -34,7 +34,10 @@ The code snippets below let an authenticated client request a grant for an incom
 
 ```ts wrap
 // Import dependencies
-import { createAuthenticatedClient } from '@interledger/open-payments'
+import {
+  createAuthenticatedClient,
+  isFinalizedGrantWithAccessToken
+} from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
@@ -66,8 +69,8 @@ const grant = await client.grant.request(
 )
 
 // Check grant state
-if (isPendingGrant(grant)) {
-  throw new Error('Expected non-interactive grant')
+if (!isFinalizedGrantWithAccessToken(grant)) {
+  throw new Error('Expected finalized grant')
 }
 
 // Output

--- a/docs/src/content/docs/sdk/grant-create-outgoing.mdx
+++ b/docs/src/content/docs/sdk/grant-create-outgoing.mdx
@@ -42,7 +42,10 @@ Any authorization server that issues interactive grants must integrate with an [
 
 ```ts wrap
 // Import dependencies
-import { createAuthenticatedClient } from '@interledger/open-payments'
+import {
+  createAuthenticatedClient,
+  isPendingGrant
+} from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
@@ -91,7 +94,7 @@ const grant = await client.grant.request(
 
 // Check grant state
 if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+  throw new Error('Expected pending/interactive grant')
 }
 
 // Output
@@ -104,7 +107,10 @@ console.log('CONTINUE_URI =', grant.continue.uri)
 
 ```ts wrap
 // Import dependencies
-import { createAuthenticatedClient } from '@interledger/open-payments'
+import {
+  createAuthenticatedClient,
+  isPendingGrant
+} from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
@@ -154,7 +160,7 @@ const grant = await client.grant.request(
 
 // Check grant state
 if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+  throw new Error('Expected pending/interactive grant')
 }
 
 // Output

--- a/docs/src/content/docs/sdk/grant-create-outgoing.mdx
+++ b/docs/src/content/docs/sdk/grant-create-outgoing.mdx
@@ -49,7 +49,7 @@ import {
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })
@@ -114,7 +114,7 @@ import {
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/grant-create-quote.mdx
+++ b/docs/src/content/docs/sdk/grant-create-quote.mdx
@@ -41,7 +41,7 @@ import {
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/grant-create-quote.mdx
+++ b/docs/src/content/docs/sdk/grant-create-quote.mdx
@@ -34,7 +34,10 @@ The code snippets below let a client request a grant for a quote. The request to
 
 ```ts wrap
 // Import dependencies
-import { createAuthenticatedClient } from '@interledger/open-payments'
+import {
+  createAuthenticatedClient,
+  isFinalizedGrantWithAccessToken
+} from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
@@ -66,8 +69,8 @@ const grant = await client.grant.request(
 )
 
 // Check grant state
-if (isPendingGrant(grant)) {
-  throw new Error('Expected non-interactive grant')
+if (!isFinalizedGrantWithAccessToken(grant)) {
+  throw new Error('Expected finalized grant')
 }
 
 // Output

--- a/docs/src/content/docs/sdk/grant-revoke.mdx
+++ b/docs/src/content/docs/sdk/grant-revoke.mdx
@@ -34,7 +34,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/incoming-complete.mdx
+++ b/docs/src/content/docs/sdk/incoming-complete.mdx
@@ -36,7 +36,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/incoming-create.mdx
+++ b/docs/src/content/docs/sdk/incoming-create.mdx
@@ -34,7 +34,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/incoming-get.mdx
+++ b/docs/src/content/docs/sdk/incoming-get.mdx
@@ -40,7 +40,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })
@@ -63,7 +63,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/incoming-list.mdx
+++ b/docs/src/content/docs/sdk/incoming-list.mdx
@@ -36,7 +36,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/outgoing-create.mdx
+++ b/docs/src/content/docs/sdk/outgoing-create.mdx
@@ -41,7 +41,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/outgoing-get.mdx
+++ b/docs/src/content/docs/sdk/outgoing-get.mdx
@@ -36,7 +36,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
+++ b/docs/src/content/docs/sdk/outgoing-grant-spent-amounts.mdx
@@ -35,7 +35,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/outgoing-list.mdx
+++ b/docs/src/content/docs/sdk/outgoing-list.mdx
@@ -36,7 +36,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/quote-create.mdx
+++ b/docs/src/content/docs/sdk/quote-create.mdx
@@ -39,7 +39,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })
@@ -312,7 +312,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })
@@ -626,7 +626,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/quote-get.mdx
+++ b/docs/src/content/docs/sdk/quote-get.mdx
@@ -34,7 +34,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/token-revoke.mdx
+++ b/docs/src/content/docs/sdk/token-revoke.mdx
@@ -34,7 +34,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/token-rotate.mdx
+++ b/docs/src/content/docs/sdk/token-rotate.mdx
@@ -36,7 +36,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/wallet-get-info.mdx
+++ b/docs/src/content/docs/sdk/wallet-get-info.mdx
@@ -30,7 +30,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/docs/src/content/docs/sdk/wallet-get-keys.mdx
+++ b/docs/src/content/docs/sdk/wallet-get-keys.mdx
@@ -31,7 +31,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 // Initialize client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-continuation.js
+++ b/snippets/node/grant/grant-continuation.js
@@ -8,7 +8,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const CONTINUE_URI = process.env.CONTINUE_URI
 const CONTINUE_ACCESS_TOKEN = process.env.CONTINUE_ACCESS_TOKEN
 const URL_WITH_INTERACT_REF = process.env.URL_WITH_INTERACT_REF
@@ -17,7 +17,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-continuation.js
+++ b/snippets/node/grant/grant-continuation.js
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv'
 import { join } from 'path'
 import { fileURLToPath } from 'url'
-import { isFinalizedGrant } from '@interledger/open-payments'
+import { isFinalizedGrantWithAccessToken } from '@interledger/open-payments'
 
 dotenv.config({
   path: fileURLToPath(join(import.meta.url, '..', '..', '.env'))
@@ -42,7 +42,7 @@ const grant = await client.grant.continue(
   }
 )
 
-if (!isFinalizedGrant(grant)) {
+if (!isFinalizedGrantWithAccessToken(grant)) {
   throw new Error('Expected finalized grant. Received non-finalized grant.')
 }
 

--- a/snippets/node/grant/grant-continuation.ts
+++ b/snippets/node/grant/grant-continuation.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const CONTINUE_URI = process.env.CONTINUE_URI
 const CONTINUE_ACCESS_TOKEN = process.env.CONTINUE_ACCESS_TOKEN
 const URL_WITH_INTERACT_REF = process.env.URL_WITH_INTERACT_REF
@@ -22,7 +22,7 @@ import {
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-continuation.ts
+++ b/snippets/node/grant/grant-continuation.ts
@@ -16,7 +16,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 //@! start chunk 1 | title=Import dependencies
 import {
   createAuthenticatedClient,
-  isFinalizedGrant
+  isFinalizedGrantWithAccessToken
 } from '@interledger/open-payments'
 //@! end chunk 1
 
@@ -51,7 +51,7 @@ const grant = await client.grant.continue(
 //@! end chunk 3
 
 //@! start chunk 4 | title=Check grant state
-if (!isFinalizedGrant(grant)) {
+if (!isFinalizedGrantWithAccessToken(grant)) {
   throw new Error('Expected finalized grant. Received non-finalized grant.')
 }
 //@! end chunk4

--- a/snippets/node/grant/grant-incoming-payment.js
+++ b/snippets/node/grant/grant-incoming-payment.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import {
@@ -16,7 +16,7 @@ import {
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-incoming-payment.js
+++ b/snippets/node/grant/grant-incoming-payment.js
@@ -12,7 +12,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import {
   createAuthenticatedClient,
-  isPendingGrant
+  isFinalizedGrantWithAccessToken
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
@@ -41,8 +41,8 @@ const grant = await client.grant.request(
   }
 )
 
-if (isPendingGrant(grant)) {
-  throw new Error('Expected non-interactive grant')
+if (isFinalizedGrantWithAccessToken(grant)) {
+  throw new Error('Expected finalized grant')
 }
 
 console.log('INCOMING_PAYMENT_ACCESS_TOKEN =', grant.access_token.value)

--- a/snippets/node/grant/grant-incoming-payment.ts
+++ b/snippets/node/grant/grant-incoming-payment.ts
@@ -13,7 +13,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 //@! start chunk 1 | title=Import dependencies
 import {
   createAuthenticatedClient,
-  isPendingGrant
+  isFinalizedGrantWithAccessToken
 } from '@interledger/open-payments'
 //@! end chunk 1
 
@@ -50,7 +50,7 @@ const grant = await client.grant.request(
 //@! end chunk 4
 
 //@! start chunk 5 | title=Check grant state
-if (isPendingGrant(grant)) {
+if (isFinalizedGrantWithAccessToken(grant)) {
   throw new Error('Expected non-interactive grant')
 }
 //@! end chunk 5

--- a/snippets/node/grant/grant-incoming-payment.ts
+++ b/snippets/node/grant/grant-incoming-payment.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 //@! start chunk 1 | title=Import dependencies
@@ -19,7 +19,7 @@ import {
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-outgoing-payment-interval.js
+++ b/snippets/node/grant/grant-outgoing-payment-interval.js
@@ -8,7 +8,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const QUOTE_URL = process.env.QUOTE_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -20,7 +20,7 @@ import {
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-outgoing-payment-interval.js
+++ b/snippets/node/grant/grant-outgoing-payment-interval.js
@@ -16,7 +16,7 @@ const NONCE = randomUUID()
 
 import {
   createAuthenticatedClient,
-  isPendingGrant
+  isFinalizedGrantWithAccessToken
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
@@ -67,8 +67,8 @@ const grant = await client.grant.request(
   }
 )
 
-if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+if (!isFinalizedGrantWithAccessToken(grant)) {
+  throw new Error('Expected pending/interactive grant')
 }
 
 console.log('Please interact at the following URL:', grant.interact.redirect)

--- a/snippets/node/grant/grant-outgoing-payment-interval.ts
+++ b/snippets/node/grant/grant-outgoing-payment-interval.ts
@@ -8,7 +8,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const QUOTE_URL = process.env.QUOTE_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -23,7 +23,7 @@ import {
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-outgoing-payment-interval.ts
+++ b/snippets/node/grant/grant-outgoing-payment-interval.ts
@@ -77,7 +77,7 @@ const grant = await client.grant.request(
 
 //@! start chunk 5 | title=Check grant state
 if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+  throw new Error('Expected pending/interactive grant')
 }
 //@! end chunk 5
 

--- a/snippets/node/grant/grant-outgoing-payment.js
+++ b/snippets/node/grant/grant-outgoing-payment.js
@@ -67,7 +67,7 @@ const grant = await client.grant.request(
 )
 
 if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+  throw new Error('Expected pending/interactive grant')
 }
 
 console.log('Please interact at the following URL:', grant.interact.redirect)

--- a/snippets/node/grant/grant-outgoing-payment.js
+++ b/snippets/node/grant/grant-outgoing-payment.js
@@ -8,7 +8,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const QUOTE_URL = process.env.QUOTE_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -20,7 +20,7 @@ import {
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-outgoing-payment.ts
+++ b/snippets/node/grant/grant-outgoing-payment.ts
@@ -76,7 +76,7 @@ const grant = await client.grant.request(
 
 //@! start chunk 5 | title=Check grant state
 if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+  throw new Error('Expected pending/interactive grant')
 }
 //@! end chunk 5
 

--- a/snippets/node/grant/grant-outgoing-payment.ts
+++ b/snippets/node/grant/grant-outgoing-payment.ts
@@ -8,7 +8,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const QUOTE_URL = process.env.QUOTE_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -23,7 +23,7 @@ import {
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-quote.js
+++ b/snippets/node/grant/grant-quote.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import {
@@ -16,7 +16,7 @@ import {
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-quote.js
+++ b/snippets/node/grant/grant-quote.js
@@ -12,7 +12,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import {
   createAuthenticatedClient,
-  isPendingGrant
+  isFinalizedGrantWithAccessToken
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
@@ -41,7 +41,7 @@ const grant = await client.grant.request(
   }
 )
 
-if (isPendingGrant(grant)) {
+if (isFinalizedGrantWithAccessToken(grant)) {
   throw new Error('Expected non-interactive grant')
 }
 

--- a/snippets/node/grant/grant-quote.ts
+++ b/snippets/node/grant/grant-quote.ts
@@ -13,7 +13,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 //@! start chunk 1 | title=Import dependencies
 import {
   createAuthenticatedClient,
-  isPendingGrant
+  isFinalizedGrantWithAccessToken
 } from '@interledger/open-payments'
 //@! end chunk 1
 
@@ -50,7 +50,7 @@ const grant = await client.grant.request(
 //@! end chunk 4
 
 //@! start chunk 5 | title=Check grant state
-if (isPendingGrant(grant)) {
+if (isFinalizedGrantWithAccessToken(grant)) {
   throw new Error('Expected non-interactive grant')
 }
 //@! end chunk 5

--- a/snippets/node/grant/grant-quote.ts
+++ b/snippets/node/grant/grant-quote.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 //@! start chunk 1 | title=Import dependencies
@@ -19,7 +19,7 @@ import {
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-revoke.js
+++ b/snippets/node/grant/grant-revoke.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const CONTINUE_URI = process.env.CONTINUE_URI
 const CONTINUE_ACCESS_TOKEN = process.env.CONTINUE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant-revoke.ts
+++ b/snippets/node/grant/grant-revoke.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const CONTINUE_URI = process.env.CONTINUE_URI
 const CONTINUE_ACCESS_TOKEN = process.env.CONTINUE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant.js
+++ b/snippets/node/grant/grant.js
@@ -8,7 +8,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 const NONCE = randomUUID()
 
@@ -18,7 +18,7 @@ import {
 } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant.js
+++ b/snippets/node/grant/grant.js
@@ -75,7 +75,7 @@ const grant = await client.grant.request(
 )
 
 if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+  throw new Error('Expected pending/interactive grant')
 }
 
 console.log('Please interact at the following URL:', grant.interact.redirect)

--- a/snippets/node/grant/grant.ts
+++ b/snippets/node/grant/grant.ts
@@ -8,7 +8,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 const NONCE = randomUUID()
 
@@ -21,7 +21,7 @@ import {
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/grant/grant.ts
+++ b/snippets/node/grant/grant.ts
@@ -84,7 +84,7 @@ const grant = await client.grant.request(
 
 //@! start chunk 5 | title=Check grant state
 if (!isPendingGrant(grant)) {
-  throw new Error('Expected interactive grant')
+  throw new Error('Expected pending/interactive grant')
 }
 //@! end chunk 5
 

--- a/snippets/node/incoming-payment/incoming-payment-complete.js
+++ b/snippets/node/incoming-payment/incoming-payment-complete.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/incoming-payment/incoming-payment-complete.ts
+++ b/snippets/node/incoming-payment/incoming-payment-complete.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/incoming-payment/incoming-payment-create.js
+++ b/snippets/node/incoming-payment/incoming-payment-create.js
@@ -7,14 +7,14 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/incoming-payment/incoming-payment-create.ts
+++ b/snippets/node/incoming-payment/incoming-payment-create.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
@@ -17,7 +17,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/incoming-payment/incoming-payment-get.js
+++ b/snippets/node/incoming-payment/incoming-payment-get.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/incoming-payment/incoming-payment-get.ts
+++ b/snippets/node/incoming-payment/incoming-payment-get.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/incoming-payment/incoming-payment-list.js
+++ b/snippets/node/incoming-payment/incoming-payment-list.js
@@ -7,14 +7,14 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/incoming-payment/incoming-payment-list.ts
+++ b/snippets/node/incoming-payment/incoming-payment-list.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_ACCESS_TOKEN = process.env.INCOMING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
@@ -17,7 +17,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/outgoing-payment/outgoing-payment-create.js
+++ b/snippets/node/outgoing-payment/outgoing-payment-create.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const OUTGOING_PAYMENT_ACCESS_TOKEN = process.env.OUTGOING_PAYMENT_ACCESS_TOKEN
 const QUOTE_URL = process.env.QUOTE_URL
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/outgoing-payment/outgoing-payment-create.ts
+++ b/snippets/node/outgoing-payment/outgoing-payment-create.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const OUTGOING_PAYMENT_ACCESS_TOKEN = process.env.OUTGOING_PAYMENT_ACCESS_TOKEN
 const QUOTE_URL = process.env.QUOTE_URL
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/outgoing-payment/outgoing-payment-get.js
+++ b/snippets/node/outgoing-payment/outgoing-payment-get.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const OUTGOING_PAYMENT_ACCESS_TOKEN = process.env.OUTGOING_PAYMENT_ACCESS_TOKEN
 const OUTGOING_PAYMENT_URL = process.env.OUTGOING_PAYMENT_URL
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/outgoing-payment/outgoing-payment-get.ts
+++ b/snippets/node/outgoing-payment/outgoing-payment-get.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const OUTGOING_PAYMENT_ACCESS_TOKEN = process.env.OUTGOING_PAYMENT_ACCESS_TOKEN
 const OUTGOING_PAYMENT_URL = process.env.OUTGOING_PAYMENT_URL
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/outgoing-payment/outgoing-payment-list.js
+++ b/snippets/node/outgoing-payment/outgoing-payment-list.js
@@ -7,14 +7,14 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const OUTGOING_PAYMENT_ACCESS_TOKEN = process.env.OUTGOING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/outgoing-payment/outgoing-payment-list.ts
+++ b/snippets/node/outgoing-payment/outgoing-payment-list.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const OUTGOING_PAYMENT_ACCESS_TOKEN = process.env.OUTGOING_PAYMENT_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
@@ -17,7 +17,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-create-debit-amount.js
+++ b/snippets/node/quote/quote-create-debit-amount.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-create-debit-amount.ts
+++ b/snippets/node/quote/quote-create-debit-amount.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-create-receive-amount.js
+++ b/snippets/node/quote/quote-create-receive-amount.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-create-receive-amount.ts
+++ b/snippets/node/quote/quote-create-receive-amount.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-create.js
+++ b/snippets/node/quote/quote-create.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-create.ts
+++ b/snippets/node/quote/quote-create.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const INCOMING_PAYMENT_URL = process.env.INCOMING_PAYMENT_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-get.js
+++ b/snippets/node/quote/quote-get.js
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const QUOTE_URL = process.env.QUOTE_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -15,7 +15,7 @@ const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/quote/quote-get.ts
+++ b/snippets/node/quote/quote-get.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const QUOTE_URL = process.env.QUOTE_URL
 const QUOTE_ACCESS_TOKEN = process.env.QUOTE_ACCESS_TOKEN
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
@@ -18,7 +18,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/token/token-revoke.js
+++ b/snippets/node/token/token-revoke.js
@@ -1,14 +1,14 @@
 import { parseTokenArgs } from 'utils/parse-token-args'
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const { ACCESS_TOKEN, MANAGE_URL } = parseTokenArgs(process.argv.slice(2))
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/token/token-revoke.ts
+++ b/snippets/node/token/token-revoke.ts
@@ -1,7 +1,7 @@
 import { parseTokenArgs } from 'utils/parse-token-args'
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const { ACCESS_TOKEN, MANAGE_URL } = parseTokenArgs(process.argv.slice(2))
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
@@ -11,7 +11,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/token/token-rotate.js
+++ b/snippets/node/token/token-rotate.js
@@ -1,14 +1,14 @@
 import { parseTokenArgs } from 'utils/parse-token-args'
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const { ACCESS_TOKEN, MANAGE_URL } = parseTokenArgs(process.argv.slice(2))
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/token/token-rotate.ts
+++ b/snippets/node/token/token-rotate.ts
@@ -1,7 +1,7 @@
 import { parseTokenArgs } from 'utils/parse-token-args'
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const { ACCESS_TOKEN, MANAGE_URL } = parseTokenArgs(process.argv.slice(2))
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
@@ -11,7 +11,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/wallet-address/wallet-address-get-keys.js
+++ b/snippets/node/wallet-address/wallet-address-get-keys.js
@@ -7,13 +7,13 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/wallet-address/wallet-address-get-keys.ts
+++ b/snippets/node/wallet-address/wallet-address-get-keys.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 //@! start chunk 1 | title=Import dependencies
@@ -16,7 +16,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/wallet-address/wallet-address-get.js
+++ b/snippets/node/wallet-address/wallet-address-get.js
@@ -7,13 +7,13 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 import { createAuthenticatedClient } from '@interledger/open-payments'
 
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })

--- a/snippets/node/wallet-address/wallet-address-get.ts
+++ b/snippets/node/wallet-address/wallet-address-get.ts
@@ -7,7 +7,7 @@ dotenv.config({
 })
 
 const KEY_ID = process.env.KEY_ID
-const WALLET_ADDRESS = process.env.WALLET_ADDRESS
+const CLIENT_WALLET_ADDRESS = process.env.CLIENT_WALLET_ADDRESS
 const PRIVATE_KEY_PATH = process.env.PRIVATE_KEY_PATH
 
 //@! start chunk 1 | title=Import dependencies
@@ -16,7 +16,7 @@ import { createAuthenticatedClient } from '@interledger/open-payments'
 
 //@! start chunk 2 | title=Initialize Open Payments client
 const client = await createAuthenticatedClient({
-  walletAddressUrl: WALLET_ADDRESS,
+  walletAddressUrl: CLIENT_WALLET_ADDRESS,
   privateKey: PRIVATE_KEY_PATH,
   keyId: KEY_ID
 })


### PR DESCRIPTION
**Description of changes**
- Replace deprecated `isFinalizedGrant` method in the Node snippets to `isFinalizedGrantWithAccessToken`
- Add `isFinalizedGrantWithAccessToken` & `isPendingGrant` checks to the Node snippets in the guides to be more explicit
- Rename WALLET_ADDRESS field in the Node client initialization snippets to more explicit `CLIENT_WALLET_ADDRESS`

Fixes OPE-268

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
