### PR TITLE
docs: add guide for verifying wallet address ownership

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -400,6 +400,13 @@ export default defineConfig({
                 es: 'Obtener una concesión de pago saliente para pagos futuros'
               },
               link: '/guides/outgoing-grant-future-payments/'
+            },
+            {
+              label: 'Verify ownership of a wallet address',
+              translations: {
+                es: 'Verificar la propiedad de una dirección de billetera'
+              },
+              link: '/guides/verify-wallet-address-ownership/'
             }
           ]
         },

--- a/docs/src/content/docs/guides/verify-wallet-address-ownership.mdx
+++ b/docs/src/content/docs/guides/verify-wallet-address-ownership.mdx
@@ -1,0 +1,137 @@
+---
+title: Verify ownership of a wallet address
+---
+
+import { LinkOut } from '@interledger/docs-design-system'
+import { Tabs, TabItem, Badge } from '@astrojs/starlight/components'
+import InteractionReq from '/src/content/docs/partials/_interaction-required.mdx'
+import Start from '/src/content/docs/partials/_grant-start-interaction.mdx'
+import Finish from '/src/content/docs/partials/_grant-finish-interaction.mdx'
+import GetWalletAddress from '/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_get-wallet-address.mdx'
+import GrantRequestVerifyOwnership from '/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_grant-request-verify-ownership.mdx'
+import RequestAGrantContinuation from '/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_request-a-grant-continuation.mdx'
+
+:::tip[Summary]
+Learn how to request a grant using the `subject` field to verify that a user owns the wallet address they provided.
+:::
+
+Open Payments supports verifying that the correct user has access to a specific wallet address through an interactive authentication flow. Rather than requesting a grant to make or receive payments (which requires an `access_token` array with permissions like `outgoing-payment` or `incoming-payment`), a client can request a grant targeting a specific `subject`.
+
+The Authorization Server (AS) interacts with the Resource Owner (RO) through the Identity Provider (IdP) to confirm their identity. The IdP verifies that the end-user owns the wallet address provided in the `subject` field.
+
+**Real-life use case: Verifying wallet address ownership during user signup**
+
+When users register on a platform and link their wallet addresses (for payouts or subscriptions), the platform wants to prevent users from claiming wallet addresses they do not own. By requesting a subject-based grant, the platform redirects the user to their wallet provider's login interface. Once verified, the platform receives a continuation grant confirming ownership.
+
+## Scenario
+
+For this guide, you'll assume the role of an app developer. The guide explains how to verify that your user owns the wallet address `https://cloudninebank.example.com/user` using a subject-based grant.
+
+## Endpoints
+
+- <Badge text="GET" variant="note" />
+  <LinkOut href="https://openpayments.dev/apis/wallet-address-server/operations/get-wallet-address/">
+    Get Wallet Address
+  </LinkOut>
+- <Badge text="POST" variant="success" />
+  <LinkOut href="https://openpayments.dev/apis/auth-server/operations/post-request/">
+    Grant Request
+  </LinkOut>
+- <Badge text="POST" variant="success" />
+  <LinkOut href="https://openpayments.dev/apis/auth-server/operations/post-continue/">
+    Grant Continuation Request
+  </LinkOut>
+
+## Steps
+
+### 1. Get wallet address information
+
+First, call the <Badge text="GET" variant="note" /> [Get Wallet Address API](/apis/wallet-address-server/operations/get-wallet-address) for the user's provided wallet address.
+
+<GetWalletAddress />
+
+<details>
+  <summary>Example response</summary>
+
+```json wrap
+{
+  "id": "https://cloudninebank.example.com/user",
+  "assetCode": "CAD",
+  "assetScale": 2,
+  "authServer": "https://auth.cloudninebank.example.com/",
+  "resourceServer": "https://cloudninebank.example.com/op"
+}
+```
+
+</details>
+
+### 2. Request a subject-based grant
+
+Use the authorization server information received in the previous step to call the <Badge text="POST" variant="success" /> [Grant Request API](/apis/auth-server/operations/post-request).
+
+Instead of specifying resources in the `access_token` array, you provide the `subject` parameter containing the wallet address.
+
+<InteractionReq />
+
+<details>
+  <summary>Example response</summary>
+
+```json wrap
+{
+  "interact": {
+    "redirect": "https://auth.cloudninebank.example.com/{...}", // uri to redirect the user to, to begin interaction
+    "finish": "..." // unique key to secure the callback
+  },
+  "continue": {
+    "access_token": {
+      "value": "..." // access token for continuing the grant request
+    },
+    "uri": "https://auth.cloudninebank.example.com/continue/{...}", // uri for continuing the grant request
+    "wait": 30
+  }
+}
+```
+
+</details>
+
+Here is how you specify the `subject` structure in your grant request:
+
+<GrantRequestVerifyOwnership />
+
+### 3. Start interaction with your user
+
+<Start />
+
+### 4. Finish interaction with your user
+
+<Finish />
+
+### 5. Request a grant continuation
+
+Once the user completes the interaction and is redirected back to your application, call the <Badge text="POST" variant="success" /> [Grant Continuation Request API](/apis/auth-server/operations/post-continue/) to finalize the verification.
+
+Issue the request to the `continue.uri` provided in the initial grant response (Step 2) and include the `interact_ref` query parameter.
+
+<RequestAGrantContinuation />
+
+<details>
+  <summary>Example response</summary>
+
+```json wrap
+{
+  "access_token": {
+    "value": "...", // final access token
+    "manage": "https://auth.cloudninebank.example.com/token/{...}" // management uri for the access token
+  },
+  "continue": {
+    "access_token": {
+      "value": "..."
+    },
+    "uri": "https://auth.cloudninebank.example.com/continue/{...}"
+  }
+}
+```
+
+</details>
+
+If the continuation request succeeds and returns the access token details, the Identity Provider (IdP) has successfully verified that the user owns the specified wallet address.

--- a/docs/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_get-wallet-address.mdx
+++ b/docs/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_get-wallet-address.mdx
@@ -1,0 +1,60 @@
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+
+<Tabs syncKey="lang">
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
+
+```ts
+const userWalletAddress = await client.walletAddress.get({
+  url: 'https://cloudninebank.example.com/user'
+})
+```
+
+ </TabItem>
+ <TabItem label='Rust' icon='seti:rust'>
+
+```rust wrap
+let user_wallet_address = client.wallet_address().get("https://cloudninebank.example.com/user").await?;
+```
+
+ </TabItem>
+
+ <TabItem label='PHP' icon='seti:php'>
+
+```php wrap
+$userWalletAddress = $client->walletAddress()->get([
+  'url' => 'https://cloudninebank.example.com/user'
+]);
+```
+
+ </TabItem>
+
+ <TabItem label='Go' icon='seti:go'>
+
+```go wrap
+userWalletAddress, err := client.WalletAddress.Get(context.TODO(), op.WalletAddressGetParams{
+  URL: "https://cloudninebank.example.com/user",
+})
+if err != nil {
+  log.Fatalf("Error fetching user wallet address: %v\n", err)
+}
+```
+
+</TabItem>
+
+<TabItem label='Java' icon='seti:java'>
+
+```java wrap
+var userWalletAddress = client.walletAddress().get("https://cloudninebank.example.com/user");
+```
+
+</TabItem>
+
+<TabItem label=".NET" icon="seti:c-sharp">
+
+```csharp wrap
+var userWalletAddress = await client.GetWalletAddressAsync("https://cloudninebank.example.com/user");
+```
+
+</TabItem>
+
+</Tabs>

--- a/docs/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_grant-request-verify-ownership.mdx
+++ b/docs/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_grant-request-verify-ownership.mdx
@@ -1,0 +1,185 @@
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+
+<Tabs syncKey="lang">
+<TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
+
+```ts
+const grant = await client.grant.request(
+  {
+    url: userWalletAddress.authServer,
+  },
+  {
+    subject: {
+      sub_ids: [
+        {
+          id: userWalletAddress.id,
+          format: 'uri',
+        },
+      ],
+    },
+    client: userWalletAddress.id,
+    interact: {
+      start: ['redirect'],
+      finish: {
+        method: 'redirect',
+        uri: 'https://paymentplatform.example/finish/{...}', // where to redirect the user to after they've completed the interaction
+        nonce: NONCE,
+      },
+    },
+  },
+);
+```
+
+ </TabItem>
+ <TabItem label='Rust' icon='seti:rust'>
+
+```rust wrap
+use open_payments::types::{InteractRequest, InteractStart, InteractFinish, InteractFinishMethod, GrantRequest, Subject, SubjectId};
+
+let subject = Subject {
+  sub_ids: vec![SubjectId {
+    id: user_wallet_address.id.clone(),
+    format: "uri".into(),
+  }],
+};
+
+let interact = InteractRequest {
+  start: Some(vec![InteractStart::Redirect]),
+  finish: Some(InteractFinish {
+    method: InteractFinishMethod::Redirect,
+    uri: Some("https://paymentplatform.example/finish/{...}".into()),
+    nonce: Some("NONCE".into()),
+  }),
+};
+
+let grant_request = GrantRequest::new_with_subject(subject, Some(interact));
+
+let pending_grant = client
+  .grant()
+  .request(&user_wallet_address.auth_server, &grant_request)
+  .await?;
+```
+
+ </TabItem>
+  <TabItem label='PHP' icon='seti:php'>
+
+```php wrap
+$grant = $client->grant()->request(
+  [
+    'url' => $userWalletAddress->authServer,
+  ],
+  [
+    'subject' => [
+      'sub_ids' => [
+        [
+          'id' => $userWalletAddress->id,
+          'format' => 'uri',
+        ],
+      ],
+    ],
+    'client' => $userWalletAddress->id,
+    'interact' => [
+      'start' => ['redirect'],
+      'finish' => [
+        'method' => 'redirect',
+        'uri' => 'https://paymentplatform.example/finish/{...}', // where to redirect the user to after they've completed the interaction
+        'nonce' => NONCE,
+      ],
+    ],
+  ],
+);
+```
+
+ </TabItem>
+ <TabItem label='Go' icon='seti:go'>
+
+```go wrap
+subject := as.Subject{
+  SubIds: []as.SubjectId{
+    {
+      Id:     *userWalletAddress.Id,
+      Format: "uri",
+    },
+  },
+}
+
+interact := &as.InteractRequest{
+  Start: []as.InteractRequestStart{as.InteractRequestStartRedirect},
+  Finish: &as.InteractRequestFinish{
+    Method: as.Redirect,
+    Uri:    "https://paymentplatform.example/finish/{...}",
+    Nonce:  NONCE,
+  },
+}
+
+pendingGrant, err := client.Grant.Request(context.TODO(), op.GrantRequestParams{
+  URL: *userWalletAddress.AuthServer,
+  RequestBody: as.GrantRequestWithSubject{
+    Subject:  subject,
+    Interact: interact,
+  },
+})
+if err != nil {
+  log.Fatalf("Error requesting grant: %v\n", err)
+}
+```
+
+  </TabItem>
+
+  <TabItem label='Java' icon='seti:java'>
+
+```java wrap
+var subject = Subject.build(userWalletAddress.getId(), "uri");
+
+var urlToOpen = "https://paymentplatform.example/finish/{...}";
+
+var grantRequest = client.auth().grant().request(
+  userWalletAddress,
+  subject,
+  URI.create(urlToOpen),
+  "NONCE"
+);
+```
+
+  </TabItem>
+
+<TabItem label='.NET' icon='seti:c-sharp'>
+
+```csharp wrap
+var grant = await client.RequestGrantAsync(
+    new RequestArgs
+    {
+        Url = userWalletAddress.AuthServer,
+    },
+    new GrantCreateBodyWithInteract
+    {
+        Subject = new Subject
+        {
+            SubIds =
+            [
+                new SubjectId
+                {
+                    Id = userWalletAddress.Id,
+                    Format = "uri"
+                }
+            ]
+        },
+        Client = userWalletAddress.Id,
+        Interact = new InteractRequest
+        {
+            Start = [Start.Redirect],
+            Finish = new Finish
+            {
+                Method = FinishMethod.Redirect,
+                Uri = new Uri(
+                    "https://paymentplatform.example/finish/{...}"), // where to redirect your user after they've completed the interaction
+                Nonce = NONCE
+            }
+        }
+    }
+);
+```
+
+</TabItem>
+
+</Tabs>

--- a/docs/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_request-a-grant-continuation.mdx
+++ b/docs/src/content/docs/partials/code/guides/verify-wallet-address-ownership/_request-a-grant-continuation.mdx
@@ -1,0 +1,102 @@
+import { Tabs, TabItem } from '@astrojs/starlight/components'
+
+<Tabs syncKey='lang'>
+  <TabItem label='TypeScript/JavaScript' icon='seti:javascript'>
+
+```ts wrap
+const userVerificationGrant = await client.grant.continue(
+  {
+    accessToken: pendingGrant.continue.access_token.value,
+    url: pendingGrant.continue.uri
+  },
+  {
+    interact_ref: interactRef
+  }
+)
+```
+
+  </TabItem>
+  <TabItem label='Rust' icon='seti:rust'>
+
+```rust wrap
+let continue_field = match &pending_grant.continue_field {
+  Some(c) => c,
+  None => {
+    eprintln!("Missing continue field on pending grant");
+    return Ok(());
+  }
+};
+
+let user_verification_grant = client
+  .grant()
+  .continue_grant(
+    &continue_field.uri,
+    &interact_ref,
+    Some(&continue_field.access_token.value),
+  )
+  .await?;
+```
+
+  </TabItem>
+
+  <TabItem label='PHP' icon='seti:php'>
+
+```php wrap
+$userVerificationGrant = $client->grant()->continue(
+  [
+    'accessToken' => $pendingGrant->continue->access_token->value,
+    'url' => $pendingGrant->continue->uri,
+  ],
+  [
+    'interact_ref' => $interactRef,
+  ],
+);
+```
+
+  </TabItem>
+
+  <TabItem label='Go' icon='seti:go'>
+
+```go wrap
+userVerificationGrant, err := client.Grant.Continue(context.TODO(), op.GrantContinueParams{
+  URL:         pendingGrant.Continue.Uri,
+  AccessToken: pendingGrant.Continue.AccessToken.Value,
+  InteractRef: INTERACT_REF,
+})
+if err != nil {
+  log.Fatalf("Error continuing grant: %v\n", err)
+}
+```
+
+  </TabItem>
+
+  <TabItem label='Java' icon='seti:java'>
+
+```java wrap
+var userVerificationGrant = client.auth().grant().finalize(
+  grantRequest,
+  interactRef
+);
+```
+
+  </TabItem>
+
+<TabItem label='.NET' icon='seti:c-sharp'>
+
+```csharp wrap
+var userVerificationGrant = await client.ContinueGrantAsync(
+    new AuthRequestArgs
+    {
+        Url = grant.Continue.Uri,
+        AccessToken = grant.Continue.AccessToken.Value
+    },
+    new GrantContinueBody()
+    {
+        InteractRef = interactRef
+    }
+);
+```
+
+</TabItem>
+
+</Tabs>


### PR DESCRIPTION
This pull request adds a new guide explaining how to verify wallet address ownership using subject-based grant requests, as requested in #716.

It includes:
- A new guide under docs/src/content/docs/guides/verify-wallet-address-ownership.mdx
- Corresponding code partials for TypeScript/JavaScript, Rust, PHP, Go, Java, and .NET
- Astro configuration update to add the guide to the sidebar navigation