### PR TITLE
docs: add llms.txt support via starlight-llms-txt plugin

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,6 +4,7 @@ import { defineConfig } from 'astro/config'
 import starlight from '@astrojs/starlight'
 import starlightOpenAPI from 'starlight-openapi'
 import starlightLinksValidator from 'starlight-links-validator'
+import starlightLlmsTxt from 'starlight-llms-txt'
 import starlightFullViewMode from 'starlight-fullview-mode'
 import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
@@ -91,6 +92,56 @@ export default defineConfig({
         src: './public/favicon.svg'
       },
       plugins: [
+        starlightLlmsTxt({
+          details: `Open Payments documentation serves two audiences: developers building payment applications using the Open Payments SDKs, and Account Servicing Entities (ASEs) implementing the protocol on their own infrastructure. The appropriate guidance differs significantly between these two groups.
+
+Key terminology notes:
+
+- Wallet addresses are URL-based identifiers for financial accounts — not cryptocurrency wallets
+- Grants are authorization tokens specific to the Open Payments grant negotiation flow — not standard OAuth grants
+- Open Payments covers the API layer for initiating and receiving payments; it does not handle settlement or the underlying transfer mechanism (that is Interledger Protocol/ILP)
+- Rafiki is the reference implementation of the Open Payments protocol — relevant when a user is asking about implementing rather than consuming the API`,
+          optionalLinks: [
+            {
+              label: 'GitHub repository',
+              url: 'https://github.com/interledger/open-payments',
+              description:
+                'Source code, issues, and contributions for the Open Payments project'
+            },
+            {
+              label: 'OpenAPI specifications',
+              url: 'https://github.com/interledger/open-payments-specifications',
+              description:
+                'Hand-authored OpenAPI YAML specs for the auth server, resource server, and wallet address server'
+            }
+          ],
+          customSets: [
+            {
+              label: 'Concepts',
+              description:
+                'Core protocol concepts including wallet addresses, grants, resources, and the Open Payments flow',
+              paths: ['concepts/**']
+            },
+            {
+              label: 'Guides',
+              description:
+                'Step-by-step implementation guides for common payment scenarios such as one-time payments, remittances, and recurring payments',
+              paths: ['guides/**']
+            },
+            {
+              label: 'Identity and Access Management',
+              description:
+                'Grant negotiation and authorization, identity providers, client keys, and HTTP signatures',
+              paths: ['identity/**']
+            },
+            {
+              label: 'Implementing Open Payments',
+              description:
+                'Guides for account servicing entities (ASEs) implementing the Open Payments protocol on their own infrastructure',
+              paths: ['implement/**']
+            }
+          ]
+        }),
         // Generate the OpenAPI documentation pages.
         starlightOpenAPI([
           {

--- a/docs/package.json
+++ b/docs/package.json
@@ -25,6 +25,7 @@
     "shiki": "^4.1.0",
     "starlight-fullview-mode": "^0.2.6",
     "starlight-links-validator": "^0.24.0",
+    "starlight-llms-txt": "0.9.0",
     "starlight-openapi": "0.24.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       starlight-links-validator:
         specifier: ^0.24.0
         version: 0.24.0(@astrojs/starlight@0.39.2)(astro@6.3.8)
+      starlight-llms-txt:
+        specifier: 0.9.0
+        version: 0.9.0(@astrojs/starlight@0.39.2)(astro@6.3.8)
       starlight-openapi:
         specifier: 0.24.0
         version: 0.24.0(@astrojs/markdown-remark@7.2.0)(@astrojs/starlight@0.39.2)(astro@6.3.8)(openapi-types@12.1.3)
@@ -1933,6 +1936,10 @@ packages:
       '@types/estree': 1.0.8
     dev: false
 
+  /@types/braces@3.0.5:
+    resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
+    dev: false
+
   /@types/d3-array@3.2.1:
     resolution: {integrity: sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==}
     dev: false
@@ -2164,6 +2171,12 @@ packages:
 
   /@types/mdx@2.0.7:
     resolution: {integrity: sha512-BG4tyr+4amr3WsSEmHn/fXPqaCba/AYZ7dsaQTiavihQunHSIxk+uAtqsjvicNpyHN6cm+B9RVrUOtW9VzIKHw==}
+    dev: false
+
+  /@types/micromatch@4.0.10:
+    resolution: {integrity: sha512-5jOhFDElqr4DKTrTEbnW8DZ4Hz5LRUEmyrGpCMrD/NphYv3nUnaF08xmSLx1rGGnyEs/kFnhiw6dCgcDqMr5PQ==}
+    dependencies:
+      '@types/braces': 3.0.5
     dev: false
 
   /@types/ms@2.1.0:
@@ -2817,7 +2830,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: 7.1.1
-    dev: true
 
   /callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -3976,7 +3988,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: 5.0.1
-    dev: true
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -4342,6 +4353,25 @@ packages:
       - supports-color
     dev: false
 
+  /hast-util-to-mdast@10.1.2:
+    resolution: {integrity: sha512-FiCRI7NmOvM4y+f5w32jPRzcxDIz+PUqDwEqn1A+1q2cdp3B8Gx7aVrXORdOKjMNDQsD1ogOr896+0jJHW1EFQ==}
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      '@ungap/structured-clone': 1.2.0
+      hast-util-phrasing: 3.0.1
+      hast-util-to-html: 9.0.5
+      hast-util-to-text: 4.0.2
+      hast-util-whitespace: 3.0.0
+      mdast-util-phrasing: 4.1.0
+      mdast-util-to-hast: 13.2.1
+      mdast-util-to-string: 4.0.0
+      rehype-minify-whitespace: 6.0.2
+      trim-trailing-lines: 2.1.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+    dev: false
+
   /hast-util-to-parse5@8.0.0:
     resolution: {integrity: sha512-3KKrV5ZVI8if87DVSi1vDeByYrkGzg4mEfeu4alwgmmIeARiBLKCZS2uw5Gb6nU9x9Yufyj3iudm6i7nl52PFw==}
     dependencies:
@@ -4554,7 +4584,6 @@ packages:
   /is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
-    dev: true
 
   /is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -5377,7 +5406,6 @@ packages:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
-    dev: true
 
   /minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -5844,8 +5872,23 @@ packages:
       vfile: 6.0.3
     dev: false
 
+  /rehype-minify-whitespace@6.0.2:
+    resolution: {integrity: sha512-Zk0pyQ06A3Lyxhe9vGtOtzz3Z0+qZ5+7icZ/PL/2x1SHPbKao5oB/g/rlc6BCTajqBb33JcOe71Ye1oFsuYbnw==}
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-minify-whitespace: 1.0.1
+    dev: false
+
   /rehype-parse@9.0.0:
     resolution: {integrity: sha512-WG7nfvmWWkCR++KEkZevZb/uw41E8TsH4DsY9UxsTbIXCVGbAs4S+r8FrQ+OtH5EEQAs+5UxKC42VinkmpA1Yw==}
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-from-html: 2.0.3
+      unified: 11.0.5
+    dev: false
+
+  /rehype-parse@9.0.1:
+    resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
     dependencies:
       '@types/hast': 3.0.4
       hast-util-from-html: 2.0.3
@@ -5868,6 +5911,16 @@ packages:
       hast-util-to-estree: 3.1.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /rehype-remark@10.0.1:
+    resolution: {integrity: sha512-EmDndlb5NVwXGfUa4c9GPK+lXeItTilLhE6ADSaQuHr4JUlKw9MidzGzx4HpqZrNCt6vnHmEifXQiiA+CEnjYQ==}
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      hast-util-to-mdast: 10.1.2
+      unified: 11.0.5
+      vfile: 6.0.3
     dev: false
 
   /rehype-stringify@10.0.1:
@@ -6286,6 +6339,30 @@ packages:
       - supports-color
     dev: false
 
+  /starlight-llms-txt@0.9.0(@astrojs/starlight@0.39.2)(astro@6.3.8):
+    resolution: {integrity: sha512-Yd/ZD0iR4U1tPkhW1O2dh1gBsMWueBni7Ht4hJVEUpoczwPy8U+Ii4OCVuYIQQYSI7crHyx60ZC+zYMqZM881Q==}
+    peerDependencies:
+      '@astrojs/starlight': '>=0.38.0'
+      astro: ^6.0.0
+    dependencies:
+      '@astrojs/mdx': 5.0.4(astro@6.3.8)
+      '@astrojs/starlight': 0.39.2(astro@6.3.8)(typescript@5.9.3)
+      '@types/hast': 3.0.4
+      '@types/micromatch': 4.0.10
+      astro: 6.3.8
+      github-slugger: 2.0.0
+      hast-util-select: 6.0.4
+      micromatch: 4.0.8
+      rehype-parse: 9.0.1
+      rehype-remark: 10.0.1
+      remark-gfm: 4.0.1
+      remark-stringify: 11.0.0
+      unified: 11.0.5
+      unist-util-remove: 4.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /starlight-openapi@0.24.0(@astrojs/markdown-remark@7.2.0)(@astrojs/starlight@0.39.2)(astro@6.3.8)(openapi-types@12.1.3):
     resolution: {integrity: sha512-h0cKk6rysSoVewQ7ueSIzFaluyvSMJKttsLMuvX1dqMt0Q3H6rdlFE401gBRfS+76LP2LtRoK0IBzsbitcRu4w==}
     engines: {node: '>=22.12.0'}
@@ -6428,10 +6505,13 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
-    dev: true
 
   /trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+    dev: false
+
+  /trim-trailing-lines@2.1.0:
+    resolution: {integrity: sha512-5UR5Biq4VlVOtzqkm2AZlgvSlDJtME46uV0br0gENbwN4l5+mMKT4b9gJKqWtuL2zAIqajGJGuvbCbcAJUZqBg==}
     dev: false
 
   /trough@2.1.0:
@@ -6585,6 +6665,14 @@ packages:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-visit: 5.0.0
+    dev: false
+
+  /unist-util-remove@4.0.0:
+    resolution: {integrity: sha512-b4gokeGId57UVRX/eVKej5gXqGlc9+trkORhFJpu9raqZkZhU0zm8Doi05+HaiBsMEIJowL+2WtQ5ItjsngPXg==}
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-is: 6.0.0
+      unist-util-visit-parents: 6.0.2
     dev: false
 
   /unist-util-stringify-position@4.0.0:


### PR DESCRIPTION
**Description of changes**
Installed `starlight-llms-txt` and configured for Open Payments. The plugin generates three routes at build time:

- /llms.txt - curated index with project description and section links
- /llms-full.txt - complete documentation in a single flat file
- /llms-small.txt - condensed version with asides and whitespace collapsed

Special configuration for Open Payments:

- `details` block explains the two main audiences (SDK developers & ASEs) and clarifies terminology that differs from common usage (wallet addresses, grants, ILP vs OP scope)
- `customSets` groups content into four named subsets (Concepts, Guides, Identity and Access Management, and Implementing Open Payments) - this helps agents pull targeted content instead of the whole file
- `optionalLinks` points to the GitHub repo for docs and the GitHub repo for the API specs

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
