### PR TITLE
fix: add doc redirect for deprecated /introduction/overview path

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -727,7 +727,8 @@ Key terminology notes:
     '/docs': '/overview/getting-started',
     '/introduction/wallet-addresses': '/concepts/wallet-addresses',
     '/sdk/grant-create': '/sdk/grant-create-incoming',
-    '/implement': '/implement/ase-overview/'
+    '/implement': '/implement/ase-overview/',
+    '/introduction/overview/': '/overview/getting-started'
   },
   server: {
     port: 1104,


### PR DESCRIPTION
**Description of changes**
Adds a doc redirect for deprecated /introduction/overview path

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
