### PR TITLE
chore: update Rust snippets for open-payments SDK 0.2.0

### DIFF
--- a/docs/src/content/docs/partials/sdk/_rust-button.mdx
+++ b/docs/src/content/docs/partials/sdk/_rust-button.mdx
@@ -1,7 +1,7 @@
 import { LinkButton } from '@astrojs/starlight/components'
 
 <LinkButton
-  href="https://github.com/interledger/open-payments-rust/blob/main/src/snippets/README.md#prerequisites"
+  href="https://github.com/interledger/open-payments-rust/blob/main/README.md#prerequisites"
   target="_blank"
   icon="external"
   iconPlacement="start"

--- a/docs/src/content/docs/sdk/grant-continue.mdx
+++ b/docs/src/content/docs/sdk/grant-continue.mdx
@@ -91,7 +91,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::auth::ContinueResponse;
 
 // Initialize client
@@ -115,6 +114,9 @@ match response {
             "Received access token manage URL: {:#?}",
             access_token.manage
         );
+    }
+    ContinueResponse::WithSubject { subject, .. } => {
+        println!("Received subject: {subject:#?}");
     }
     ContinueResponse::Pending { .. } => {
         println!("Pending");

--- a/docs/src/content/docs/sdk/grant-create-incoming.mdx
+++ b/docs/src/content/docs/sdk/grant-create-incoming.mdx
@@ -99,7 +99,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::auth::{
     AccessItem, AccessTokenRequest, GrantRequest, GrantResponse, IncomingPaymentAction,
 };
@@ -136,7 +135,7 @@ println!(
 
 let response = client
     .grant()
-    .request(&wallet_address.auth_server, &grant_request)
+    .request(&wallet_address.auth_server, &grant_request, None)
     .await?;
 
 // Output

--- a/docs/src/content/docs/sdk/grant-create-outgoing.mdx
+++ b/docs/src/content/docs/sdk/grant-create-outgoing.mdx
@@ -187,7 +187,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::{
     auth::{
         AccessItem, AccessTokenRequest, GrantRequest, InteractFinish, InteractRequest,
@@ -246,7 +245,7 @@ println!(
 
 let response = client
     .grant()
-    .request(&wallet_address.auth_server, &grant_request)
+    .request(&wallet_address.auth_server, &grant_request, None)
     .await?;
 
 // Output

--- a/docs/src/content/docs/sdk/grant-create-quote.mdx
+++ b/docs/src/content/docs/sdk/grant-create-quote.mdx
@@ -96,7 +96,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::{
     auth::{AccessItem, AccessTokenRequest, GrantRequest, QuoteAction},
     GrantResponse,
@@ -127,7 +126,7 @@ println!(
 
 let response = client
     .grant()
-    .request(&wallet_address.auth_server, &grant_request)
+    .request(&wallet_address.auth_server, &grant_request, None)
     .await?;
 
 // Output

--- a/docs/src/content/docs/sdk/grant-revoke.mdx
+++ b/docs/src/content/docs/sdk/grant-revoke.mdx
@@ -63,7 +63,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/incoming-complete.mdx
+++ b/docs/src/content/docs/sdk/incoming-complete.mdx
@@ -68,7 +68,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/incoming-create.mdx
+++ b/docs/src/content/docs/sdk/incoming-create.mdx
@@ -85,7 +85,6 @@ use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::api::UnauthenticatedResources;
 use open_payments::client::utils::get_resource_server_url;
 use open_payments::client::OpClientError;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::{resource::CreateIncomingPaymentRequest, Amount};
 
 // Initialize client

--- a/docs/src/content/docs/sdk/incoming-get.mdx
+++ b/docs/src/content/docs/sdk/incoming-get.mdx
@@ -96,7 +96,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;
@@ -120,7 +119,6 @@ println!("Incoming payment: {payment:#?}");
 ```rust wrap
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/incoming-list.mdx
+++ b/docs/src/content/docs/sdk/incoming-list.mdx
@@ -83,7 +83,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/outgoing-create.mdx
+++ b/docs/src/content/docs/sdk/outgoing-create.mdx
@@ -85,7 +85,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::OutgoingPaymentRequest;
 
 // Initialize client

--- a/docs/src/content/docs/sdk/outgoing-get.mdx
+++ b/docs/src/content/docs/sdk/outgoing-get.mdx
@@ -68,7 +68,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/outgoing-list.mdx
+++ b/docs/src/content/docs/sdk/outgoing-list.mdx
@@ -83,7 +83,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/quote-create.mdx
+++ b/docs/src/content/docs/sdk/quote-create.mdx
@@ -84,7 +84,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::{resource::CreateQuoteRequest, PaymentMethodType, Receiver};
 
 // Initialize client
@@ -362,7 +361,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::{resource::CreateQuoteRequest, Amount, PaymentMethodType, Receiver};
 
 // Initialize client
@@ -676,7 +674,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::{resource::CreateQuoteRequest, Amount, PaymentMethodType, Receiver};
 
 // Initialize client

--- a/docs/src/content/docs/sdk/quote-get.mdx
+++ b/docs/src/content/docs/sdk/quote-get.mdx
@@ -66,7 +66,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/token-revoke.mdx
+++ b/docs/src/content/docs/sdk/token-revoke.mdx
@@ -63,7 +63,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/token-rotate.mdx
+++ b/docs/src/content/docs/sdk/token-rotate.mdx
@@ -69,7 +69,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_authenticated_client()?;

--- a/docs/src/content/docs/sdk/wallet-get-info.mdx
+++ b/docs/src/content/docs/sdk/wallet-get-info.mdx
@@ -61,7 +61,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
-use open_payments::snippets::utils::{create_unauthenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_unauthenticated_client();

--- a/docs/src/content/docs/sdk/wallet-get-keys.mdx
+++ b/docs/src/content/docs/sdk/wallet-get-keys.mdx
@@ -61,7 +61,6 @@ For JavaScript, run `node path/to/directory/index.js`. <LinkOut href='https://gi
 ```rust wrap
 // Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
-use open_payments::snippets::utils::{create_unauthenticated_client, get_env_var, load_env};
 
 // Initialize client
 let client = create_unauthenticated_client();

--- a/snippets/rust/grant/grant-continuation.rs
+++ b/snippets/rust/grant/grant-continuation.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::auth::ContinueResponse;
 //@! end chunk 1
 
@@ -31,6 +33,9 @@ async fn main() -> open_payments::client::Result<()> {
                 "Received access token manage URL: {:#?}",
                 access_token.manage
             );
+        }
+        ContinueResponse::WithSubject { subject, .. } => {
+            println!("Received subject: {:#?}", subject);
         }
         ContinueResponse::Pending { .. } => {
             println!("Pending");

--- a/snippets/rust/grant/grant-directed-identity.rs
+++ b/snippets/rust/grant/grant-directed-identity.rs
@@ -4,9 +4,8 @@ use open_payments::client::AuthenticatedResources;
 #[path = "../utils.rs"]
 mod snippet_utils;
 use snippet_utils::{create_authenticated_client, get_env_var, load_env};
-use open_payments::types::{
-    auth::{AccessItem, AccessTokenRequest, GrantRequest, QuoteAction},
-    GrantResponse,
+use open_payments::types::auth::{
+    AccessItem, AccessTokenRequest, GrantRequest, GrantResponse, IncomingPaymentAction,
 };
 //@! end chunk 1
 
@@ -15,7 +14,6 @@ async fn main() -> open_payments::client::Result<()> {
     load_env()?;
 
     //@! start chunk 2 | title=Initialize Open Payments client
-    // Authenticated client can be also used for unauthenticated resources
     let client = create_authenticated_client()?;
     //@! end chunk 2
 
@@ -24,24 +22,30 @@ async fn main() -> open_payments::client::Result<()> {
     let wallet_address = client.wallet_address().get(&wallet_address_url).await?;
     //@! end chunk 3
 
-    //@! start chunk 4 | title=Request quote grant
+    //@! start chunk 4 | title=Request incoming payment grant with directed identity
+    let jwk = client.public_jwk();
+
     let grant_request = GrantRequest::new(
         AccessTokenRequest {
-            access: vec![AccessItem::Quote {
-                actions: vec![QuoteAction::Create, QuoteAction::Read, QuoteAction::ReadAll],
+            access: vec![AccessItem::IncomingPayment {
+                actions: vec![
+                    IncomingPaymentAction::Create,
+                    IncomingPaymentAction::Read,
+                    IncomingPaymentAction::Complete,
+                ],
+                identifier: None,
             }],
         },
         None,
     );
 
-    println!(
-        "Grant request JSON: {}",
-        serde_json::to_string_pretty(&grant_request)?
-    );
-
     let response = client
         .grant()
-        .request(&wallet_address.auth_server, &grant_request, None)
+        .request(
+            &wallet_address.auth_server,
+            &grant_request,
+            Some(&jwk),
+        )
         .await?;
     //@! end chunk 4
 
@@ -55,7 +59,7 @@ async fn main() -> open_payments::client::Result<()> {
             );
         }
         GrantResponse::WithInteraction { .. } => {
-            unreachable!("Interaction not required for quotes");
+            unreachable!("Interaction not required for incoming payments");
         }
     }
     //@! end chunk 5

--- a/snippets/rust/grant/grant-incoming-payment.rs
+++ b/snippets/rust/grant/grant-incoming-payment.rs
@@ -1,7 +1,9 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::auth::{
     AccessItem, AccessTokenRequest, GrantRequest, GrantResponse, IncomingPaymentAction,
 };
@@ -45,7 +47,7 @@ async fn main() -> open_payments::client::Result<()> {
 
     let response = client
         .grant()
-        .request(&wallet_address.auth_server, &grant_request)
+        .request(&wallet_address.auth_server, &grant_request, None)
         .await?;
     //@! end chunk 4
 

--- a/snippets/rust/grant/grant-outgoing-payment.rs
+++ b/snippets/rust/grant/grant-outgoing-payment.rs
@@ -1,7 +1,9 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 use open_payments::types::{
     auth::{
         AccessItem, AccessTokenRequest, GrantRequest, InteractFinish, InteractRequest,
@@ -67,7 +69,7 @@ async fn main() -> open_payments::client::Result<()> {
 
     let response = client
         .grant()
-        .request(&wallet_address.auth_server, &grant_request)
+        .request(&wallet_address.auth_server, &grant_request, None)
         .await?;
     //@! end chunk 4
 

--- a/snippets/rust/grant/grant-revoke.rs
+++ b/snippets/rust/grant/grant-revoke.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/incoming-payment/incoming-payment-complete.rs
+++ b/snippets/rust/incoming-payment/incoming-payment-complete.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/incoming-payment/incoming-payment-create.rs
+++ b/snippets/rust/incoming-payment/incoming-payment-create.rs
@@ -2,15 +2,15 @@ use chrono::{Duration, Utc};
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
 use open_payments::client::api::UnauthenticatedResources;
-use open_payments::client::utils::get_resource_server_url;
-use open_payments::client::OpClientError;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
 use open_payments::types::{resource::CreateIncomingPaymentRequest, Amount};
 //@! end chunk 1
 
 #[tokio::main]
 async fn main() -> open_payments::client::Result<()> {
-    load_env().map_err(|e| OpClientError::other(e.to_string()))?;
+    load_env()?;
 
     //@! start chunk 2 | title=Initialize Open Payments client
     let client = create_authenticated_client()?;

--- a/snippets/rust/incoming-payment/incoming-payment-get-public.rs
+++ b/snippets/rust/incoming-payment/incoming-payment-get-public.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
-use open_payments::snippets::utils::{create_unauthenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_unauthenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/incoming-payment/incoming-payment-get.rs
+++ b/snippets/rust/incoming-payment/incoming-payment-get.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/incoming-payment/incoming-payment-list.rs
+++ b/snippets/rust/incoming-payment/incoming-payment-list.rs
@@ -1,7 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/outgoing-payment/outgoing-payment-create.rs
+++ b/snippets/rust/outgoing-payment/outgoing-payment-create.rs
@@ -1,7 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
 use open_payments::types::OutgoingPaymentRequest;
 //@! end chunk 1
 

--- a/snippets/rust/outgoing-payment/outgoing-payment-get.rs
+++ b/snippets/rust/outgoing-payment/outgoing-payment-get.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/outgoing-payment/outgoing-payment-grant-spent-amounts.rs
+++ b/snippets/rust/outgoing-payment/outgoing-payment-grant-spent-amounts.rs
@@ -1,0 +1,40 @@
+//@! start chunk 1 | title=Import dependencies
+use open_payments::client::api::{AuthenticatedResources, UnauthenticatedResources};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
+//@! end chunk 1
+
+#[tokio::main]
+async fn main() -> open_payments::client::Result<()> {
+    load_env()?;
+
+    //@! start chunk 2 | title=Initialize Open Payments client
+    let client = create_authenticated_client()?;
+    //@! end chunk 2
+
+    //@! start chunk 3 | title=Get spent amounts for current outgoing payment grant
+    let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
+    let resource_server_url =
+        get_resource_server_url(&wallet_address_url)?;
+    let access_token = get_env_var("OUTGOING_PAYMENT_ACCESS_TOKEN")?;
+
+    let grant_spent_amounts = client
+        .outgoing_payments()
+        .get_grant_spent_amounts(&resource_server_url, Some(&access_token))
+        .await?;
+    //@! end chunk 3
+
+    //@! start chunk 4 | title=Output
+    println!(
+        "GRANT_SPENT_DEBIT_AMOUNT: {:#?}",
+        grant_spent_amounts.spent_debit_amount
+    );
+    println!(
+        "GRANT_SPENT_RECEIVE_AMOUNT: {:#?}",
+        grant_spent_amounts.spent_receive_amount
+    );
+    //@! end chunk 4
+
+    Ok(())
+}

--- a/snippets/rust/outgoing-payment/outgoing-payment-list.rs
+++ b/snippets/rust/outgoing-payment/outgoing-payment-list.rs
@@ -1,7 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/quote/quote-create-debit-amount.rs
+++ b/snippets/rust/quote/quote-create-debit-amount.rs
@@ -1,7 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
 use open_payments::types::{resource::CreateQuoteRequest, Amount, PaymentMethodType, Receiver};
 //@! end chunk 1
 

--- a/snippets/rust/quote/quote-create-receive-amount.rs
+++ b/snippets/rust/quote/quote-create-receive-amount.rs
@@ -1,7 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
 use open_payments::types::{resource::CreateQuoteRequest, Amount, PaymentMethodType, Receiver};
 //@! end chunk 1
 

--- a/snippets/rust/quote/quote-create.rs
+++ b/snippets/rust/quote/quote-create.rs
@@ -1,7 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::client::utils::get_resource_server_url;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, get_resource_server_url, load_env};
 use open_payments::types::{resource::CreateQuoteRequest, PaymentMethodType, Receiver};
 //@! end chunk 1
 

--- a/snippets/rust/quote/quote-get.rs
+++ b/snippets/rust/quote/quote-get.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/token/token-revoke.rs
+++ b/snippets/rust/token/token-revoke.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/token/token-rotate.rs
+++ b/snippets/rust/token/token-rotate.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::AuthenticatedResources;
-use open_payments::snippets::utils::{create_authenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_authenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/utils.rs
+++ b/snippets/rust/utils.rs
@@ -1,0 +1,45 @@
+use open_payments::client::{
+    AuthenticatedClient, ClientConfig, OpClientError, Result, UnauthenticatedClient,
+};
+use open_payments::client::utils as client_utils;
+use open_payments::http_signature::jwk::Jwk;
+use dotenv::dotenv;
+use std::{env, path::PathBuf};
+
+pub fn load_env() -> Result<()> {
+    dotenv().ok();
+    Ok(())
+}
+
+pub fn get_env_var(key: &str) -> Result<String> {
+    env::var(key).map_err(|_| {
+        OpClientError::other(format!("{key} environment variable not set")).into()
+    })
+}
+
+pub fn create_authenticated_client() -> Result<AuthenticatedClient> {
+    let wallet_address_url = get_env_var("WALLET_ADDRESS_URL")?;
+    let private_key_path = PathBuf::from(get_env_var("PRIVATE_KEY_PATH")?);
+    let key_id = get_env_var("KEY_ID")?;
+    let key_id_clone = key_id.clone();
+    let jwks_path = get_env_var("JWKS_PATH").ok().map(PathBuf::from);
+
+    let client = AuthenticatedClient::new(ClientConfig {
+        key_id,
+        private_key_path,
+        jwks_path,
+        wallet_address_url,
+    })
+    .map_err(|e| OpClientError::other(format!("Client creation error: {e}")))?;
+    Jwk::new(key_id_clone, Some(&client.signing_key))
+        .map_err(|e| OpClientError::other(format!("JWK error: {e}")))?;
+    Ok(client)
+}
+
+pub fn create_unauthenticated_client() -> UnauthenticatedClient {
+    UnauthenticatedClient::new()
+}
+
+pub fn get_resource_server_url(wallet_address_url: &str) -> Result<String> {
+    client_utils::get_resource_server_url(wallet_address_url)
+}

--- a/snippets/rust/wallet-address/wallet-address-get-keys.rs
+++ b/snippets/rust/wallet-address/wallet-address-get-keys.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
-use open_payments::snippets::utils::{create_unauthenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_unauthenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]

--- a/snippets/rust/wallet-address/wallet-address-get.rs
+++ b/snippets/rust/wallet-address/wallet-address-get.rs
@@ -1,6 +1,8 @@
 //@! start chunk 1 | title=Import dependencies
 use open_payments::client::api::UnauthenticatedResources;
-use open_payments::snippets::utils::{create_unauthenticated_client, get_env_var, load_env};
+#[path = "../utils.rs"]
+mod snippet_utils;
+use snippet_utils::{create_unauthenticated_client, get_env_var, load_env};
 //@! end chunk 1
 
 #[tokio::main]


### PR DESCRIPTION
**Description of changes**

- Updates **snippets/rust** for [open-payments-rust 0.2.0](https://github.com/interledger/open-payments-rust/releases/tag/v0.2.0) after snippets were removed from the SDK crate.
- Add **snippets/rust/utils.rs** (replaces `open_payments::snippets::utils`)
- Update snippet sources: `grant().request(..., client_override)`, `ContinueResponse::WithSubject`, `get_resource_server_url` via `utils`
- Add `grant-directed-identity.rs` and `outgoing-payment-grant-spent-amounts.rs`
- Minimal SDK doc tab updates: 0.2.0 API fixes, remove dead `snippets::utils` import, fix Rust prerequisites link

Fixes OPE-278

**Checklist**

- PR title is prefixed with `docs:`
- PR title or description includes a `fixes #`
- You've run `pnpm format` and `pnpm lint`
- You've reviewed Vale errors and made changes where appropriate
